### PR TITLE
parser: store side effects separately from values

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -653,6 +653,16 @@ mod tests {
   }
 
   #[rstest]
+  fn test_store_does_not_affect_stack_indices() {
+    let src = array![[0.2f32]];
+    let dst = run_expr_ndarray(
+      "7 6 5 4 3 2 1 0 dup4 max_val! dup3 min_val! drop8 x min_val@ max_val@ clamp",
+      &src,
+    );
+    assert_relative_eq!(dst[[0, 0]], 3.0);
+  }
+
+  #[rstest]
   #[case("10 0 20 clip", 10.0)]
   #[case("-10 0 20 clip", 0.0)]
   #[case("30 0 20 clip", 20.0)]

--- a/crates/cranexpr-parser/src/errors.rs
+++ b/crates/cranexpr-parser/src/errors.rs
@@ -30,6 +30,9 @@ pub enum ParseError {
   #[error("Attempt to swap out of bounds.")]
   SwapOutOfBounds,
 
+  #[error("Reference to uninitialized variable: {0}@")]
+  UninitializedVariable(String),
+
   #[error("Unrecognized token: {0}")]
   UnrecognizedToken(String),
 }

--- a/crates/cranexpr-parser/src/lib.rs
+++ b/crates/cranexpr-parser/src/lib.rs
@@ -33,6 +33,7 @@ fn add_ternary_op(stack: &mut Vec<Expr>, op: TernaryOp) -> Result<(), ParseError
 /// Returns a [`ParseError`] if the expression is malformed.
 pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
   let mut stack = Vec::new();
+  let mut side_effects = Vec::new();
 
   // We don't filter out whitespace tokens because they're significant when it
   // comes to differentiating between subtraction (`x - y`) and
@@ -239,7 +240,7 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
         else if tokens.peek().is_some_and(|(k, _)| *k == TokenKind::Bang) {
           tokens.next(); // Consume `!`.
           let value = stack.pop().ok_or(ParseError::StackUnderflow)?;
-          stack.push(Expr::Store(text.to_string(), Box::new(value)));
+          side_effects.push(Expr::Store(text.to_string(), Box::new(value)));
         }
         // `var@`: Pushes the value of the variable `var` onto the stack.
         else if tokens.peek().is_some_and(|(k, _)| *k == TokenKind::At) {
@@ -309,23 +310,15 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
     }
   }
 
-  if let Some((last_expr, preceding_exprs)) = stack.split_last() {
-    // All expressions before the final one must be side effects.
-    for expr in preceding_exprs {
-      if !matches!(expr, Expr::Store(..)) {
-        return Err(ParseError::ExpressionDoesNotEvaluateToSingleValue);
-      }
-    }
-
-    // Last expression must not be a side effect.
-    if matches!(last_expr, Expr::Store(..)) {
+  if stack.len() != 1 {
+    if stack.is_empty() {
       return Err(ParseError::ExpressionEvaluatesToNothing);
     }
-  } else {
-    return Err(ParseError::ExpressionEvaluatesToNothing);
+    return Err(ParseError::ExpressionDoesNotEvaluateToSingleValue);
   }
 
-  Ok(stack)
+  side_effects.extend(stack);
+  Ok(side_effects)
 }
 
 #[cfg(test)]
@@ -389,5 +382,13 @@ mod tests {
   #[rstest]
   fn test_variables() {
     assert_yaml_snapshot!(parse_expr("x 2 / my_var! my_var@ my_var@ *").unwrap());
+  }
+
+  #[rstest]
+  fn test_store_does_not_affect_stack() {
+    assert_yaml_snapshot!(
+      parse_expr("7 6 5 4 3 2 1 0 dup4 max_val! dup3 min_val! drop8 x min_val@ max_val@ clamp")
+        .unwrap()
+    );
   }
 }

--- a/crates/cranexpr-parser/src/lib.rs
+++ b/crates/cranexpr-parser/src/lib.rs
@@ -245,6 +245,15 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
         // `var@`: Pushes the value of the variable `var` onto the stack.
         else if tokens.peek().is_some_and(|(k, _)| *k == TokenKind::At) {
           tokens.next(); // Consume `@`.
+
+          // Assert that the variable has been previously initialized by a
+          // `var!` expression.
+          if !side_effects
+            .iter()
+            .any(|e| matches!(e, Expr::Store(name, _) if name == text))
+          {
+            return Err(ParseError::UninitializedVariable(text.to_string()));
+          }
           stack.push(Expr::Load(text.to_string()));
         } else {
           match text {
@@ -390,5 +399,11 @@ mod tests {
       parse_expr("7 6 5 4 3 2 1 0 dup4 max_val! dup3 min_val! drop8 x min_val@ max_val@ clamp")
         .unwrap()
     );
+  }
+
+  #[rstest]
+  fn test_load_before_store_is_error() {
+    let err = parse_expr("foo@ x 2 * foo!").unwrap_err();
+    assert_eq!(err.to_string(), "Reference to uninitialized variable: foo@");
   }
 }

--- a/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__store_does_not_affect_stack.snap
+++ b/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__store_does_not_affect_stack.snap
@@ -1,0 +1,15 @@
+---
+source: crates/cranexpr-parser/src/lib.rs
+expression: "parse_expr(\"7 6 5 4 3 2 1 0 dup4 max_val! dup3 min_val! drop8 x min_val@ max_val@ clamp\").unwrap()"
+---
+- Store:
+    - max_val
+    - Lit: 4
+- Store:
+    - min_val
+    - Lit: 3
+- Ternary:
+    - Clip
+    - Ident: x
+    - Load: min_val
+    - Load: max_val


### PR DESCRIPTION
`var!` was being pushed onto the same stack used by stack manipulation
operators, causing those operators to work on the wrong stack indices.
This made an expression like this:

    7 6 5 4 3 2 1 0 dup4 max_val! dup3 min_val! drop8 x min_val@ max_val@ clamp

fail with "Expression does not evaluate to a single value."

This patch splits parser state into a `value_stack` (for stack
manipulation operators) and a `side_effects` stack (variable stores).
This might end up being a temporary solution until the stack
manipulation operators are moved to codegen.