### PR TITLE
codegen: add `xor`, `>=`, and `<=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ core.cranexpr.Expr([x], "x[-1,-1] x[0,-1] x[1,-1] x[-1,0] x x[1,0] x[-1,1] x[0,1
 
 - Arithmetic: `+`, `-`, `*`, `/`, `%`, `pow`, `exp`, `log`, `sqrt`.
 - Trigonometry: `sin`, `cos`, `tan`, `atan2`.
-- Comparison: `>`, `<`, `=`.
+- Comparison: `>`, `<`, `=`, `>=`, `<=`.
 - Logical: `and`, `or`, `not`.
 - Bitwise: `bitand`, `bitor`, `bitxor`, `bitnot`.
 - Clamping: `min`, `max`, `clip` (alias: `clamp`).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ core.cranexpr.Expr([x], "x[-1,-1] x[0,-1] x[1,-1] x[-1,0] x x[1,0] x[-1,1] x[0,1
 - Arithmetic: `+`, `-`, `*`, `/`, `%`, `pow`, `exp`, `log`, `sqrt`.
 - Trigonometry: `sin`, `cos`, `tan`, `atan2`.
 - Comparison: `>`, `<`, `=`, `>=`, `<=`.
-- Logical: `and`, `or`, `not`.
+- Logical: `and`, `or`, `xor`, `not`.
 - Bitwise: `bitand`, `bitor`, `bitxor`, `bitnot`.
 - Clamping: `min`, `max`, `clip` (alias: `clamp`).
 - Rounding: `floor`, `round`, `trunc`.

--- a/crates/cranexpr-ast/src/lib.rs
+++ b/crates/cranexpr-ast/src/lib.rs
@@ -79,6 +79,9 @@ pub enum BinOp {
   /// Logical OR
   #[strum(serialize = "or")]
   Or,
+  /// Logical XOR
+  #[strum(serialize = "xor")]
+  Xor,
 }
 
 /// Unary operator.

--- a/crates/cranexpr-ast/src/lib.rs
+++ b/crates/cranexpr-ast/src/lib.rs
@@ -45,6 +45,12 @@ pub enum BinOp {
   /// The `=` operator (equal to)
   #[strum(serialize = "=")]
   Eq,
+  /// The `>=` operator (greater than or equal to)
+  #[strum(serialize = ">=")]
+  Gte,
+  /// The `<=` operator (less than or equal to)
+  #[strum(serialize = "<=")]
+  Lte,
 
   /// The `max` operator (maximum)
   #[strum(serialize = "max")]

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -911,6 +911,17 @@ mod tests {
   }
 
   #[rstest]
+  #[case("1 1 xor", 0.0)]
+  #[case("1 0 xor", 1.0)]
+  #[case("0 1 xor", 1.0)]
+  #[case("0 0 xor", 0.0)]
+  #[case("-1 1 xor", 1.0)]
+  #[case("5 3 xor", 0.0)]
+  fn test_xor(#[case] expr: &str, #[case] expected: f32) {
+    assert_relative_eq!(run_expr(expr), expected);
+  }
+
+  #[rstest]
   #[case("5 3 bitand", 1.0)] // 101 & 011 = 001 (1)
   #[case("5.2 2.8 bitand", 1.0)] // 5 & 3 = 1
   #[case("6 3 bitor", 7.0)] // 110 | 011 = 111 (7)

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -808,6 +808,22 @@ mod tests {
   }
 
   #[rstest]
+  #[case("5 3 >=", 1.0)]
+  #[case("3 5 >=", 0.0)]
+  #[case("5 5 >=", 1.0)]
+  fn test_gte(#[case] expr: &str, #[case] expected: f32) {
+    assert_relative_eq!(run_expr(expr), expected);
+  }
+
+  #[rstest]
+  #[case("3 5 <=", 1.0)]
+  #[case("5 3 <=", 0.0)]
+  #[case("5 5 <=", 1.0)]
+  fn test_lte(#[case] expr: &str, #[case] expected: f32) {
+    assert_relative_eq!(run_expr(expr), expected);
+  }
+
+  #[rstest]
   #[case("0 1 atan2", 0.0)]
   #[case("1 1 atan2", PI / 4.0)]
   #[case("1 0 atan2", PI / 2.0)]

--- a/crates/cranexpr-codegen/src/translate.rs
+++ b/crates/cranexpr-codegen/src/translate.rs
@@ -389,6 +389,13 @@ fn codegen_float_binop(fx: &mut FunctionCx<'_, '_>, op: BinOp, lhs: Value, rhs: 
       let result = fx.bcx.ins().bor(lhs_bool, rhs_bool);
       bool_to_float(fx, result)
     }
+    BinOp::Xor => {
+      let zero = fx.bcx.ins().f32const(0.0);
+      let lhs_bool = fx.bcx.ins().fcmp(FloatCC::GreaterThan, lhs, zero);
+      let rhs_bool = fx.bcx.ins().fcmp(FloatCC::GreaterThan, rhs, zero);
+      let result = fx.bcx.ins().bxor(lhs_bool, rhs_bool);
+      bool_to_float(fx, result)
+    }
     BinOp::BitAnd | BinOp::BitOr | BinOp::BitXor => {
       let lhs_rounded = fx.bcx.ins().nearest(lhs);
       let rhs_rounded = fx.bcx.ins().nearest(rhs);

--- a/crates/cranexpr-codegen/src/translate.rs
+++ b/crates/cranexpr-codegen/src/translate.rs
@@ -360,10 +360,12 @@ fn codegen_float_binop(fx: &mut FunctionCx<'_, '_>, op: BinOp, lhs: Value, rhs: 
     BinOp::Div => fx.bcx.ins().fdiv(lhs, rhs),
     BinOp::Pow => translate_float_intrinsic_call(fx, "powf", &[lhs, rhs]),
     BinOp::Rem => translate_float_intrinsic_call(fx, "fmodf", &[lhs, rhs]),
-    BinOp::Gt | BinOp::Lt | BinOp::Eq => {
+    BinOp::Gt | BinOp::Gte | BinOp::Lt | BinOp::Lte | BinOp::Eq => {
       let float_cc = match op {
         BinOp::Gt => FloatCC::GreaterThan,
+        BinOp::Gte => FloatCC::GreaterThanOrEqual,
         BinOp::Lt => FloatCC::LessThan,
+        BinOp::Lte => FloatCC::LessThanOrEqual,
         BinOp::Eq => FloatCC::Equal,
         _ => unreachable!("{:?}({:?}, {:?})", op, lhs, rhs),
       };

--- a/crates/cranexpr-lexer/src/lib.rs
+++ b/crates/cranexpr-lexer/src/lib.rs
@@ -37,8 +37,12 @@ pub enum TokenKind {
   Minus,
   /// `<`
   Lt,
+  /// `<=`
+  Lte,
   /// `>`
   Gt,
+  /// `>=`
+  Gte,
   /// `%`
   Percent,
   /// `!`
@@ -169,8 +173,22 @@ impl Cursor<'_> {
       '+' => TokenKind::Plus,
       '*' => TokenKind::Star,
       '/' => TokenKind::Slash,
-      '<' => TokenKind::Lt,
-      '>' => TokenKind::Gt,
+      '<' => {
+        if self.first() == '=' {
+          self.bump();
+          TokenKind::Lte
+        } else {
+          TokenKind::Lt
+        }
+      }
+      '>' => {
+        if self.first() == '=' {
+          self.bump();
+          TokenKind::Gte
+        } else {
+          TokenKind::Gt
+        }
+      }
       '%' => TokenKind::Percent,
       '!' => TokenKind::Bang,
       '@' => TokenKind::At,
@@ -412,6 +430,8 @@ mod tests {
   fn test_binary_ops() {
     assert_yaml_snapshot!(lex("d e <"));
     assert_yaml_snapshot!(lex("a b ="));
+    assert_yaml_snapshot!(lex("a b >="));
+    assert_yaml_snapshot!(lex("a b <="));
   }
 
   #[rstest]

--- a/crates/cranexpr-lexer/src/snapshots/cranexpr_lexer__tests__binary_ops-3.snap
+++ b/crates/cranexpr-lexer/src/snapshots/cranexpr_lexer__tests__binary_ops-3.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cranexpr-lexer/src/lib.rs
+expression: "lex(\"a b >=\")"
+---
+- kind: Ident
+  len: 1
+- kind: Whitespace
+  len: 1
+- kind: Ident
+  len: 1
+- kind: Whitespace
+  len: 1
+- kind: Gte
+  len: 2

--- a/crates/cranexpr-lexer/src/snapshots/cranexpr_lexer__tests__binary_ops-4.snap
+++ b/crates/cranexpr-lexer/src/snapshots/cranexpr_lexer__tests__binary_ops-4.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cranexpr-lexer/src/lib.rs
+expression: "lex(\"a b <=\")"
+---
+- kind: Ident
+  len: 1
+- kind: Whitespace
+  len: 1
+- kind: Ident
+  len: 1
+- kind: Whitespace
+  len: 1
+- kind: Lte
+  len: 2

--- a/crates/cranexpr-parser/src/lib.rs
+++ b/crates/cranexpr-parser/src/lib.rs
@@ -305,6 +305,7 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
             "bitnot" => add_unary_op(&mut stack, UnOp::BitNot),
             "and" => add_binary_op(&mut stack, BinOp::And),
             "or" => add_binary_op(&mut stack, BinOp::Or),
+            "xor" => add_binary_op(&mut stack, BinOp::Xor),
             _ => {
               stack.push(Expr::Ident(text.to_string()));
               Ok(())
@@ -432,6 +433,11 @@ mod tests {
   fn test_and_or() {
     assert_yaml_snapshot!(parse_expr("x 0 > y 0 > and").unwrap());
     assert_yaml_snapshot!(parse_expr("x 0 > y 0 > or").unwrap());
+  }
+
+  #[rstest]
+  fn test_xor() {
+    assert_yaml_snapshot!(parse_expr("x 0 > y 0 > xor").unwrap());
   }
 
   #[rstest]

--- a/crates/cranexpr-parser/src/lib.rs
+++ b/crates/cranexpr-parser/src/lib.rs
@@ -331,7 +331,9 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
       TokenKind::Star => add_binary_op(&mut stack, BinOp::Mul)?,
       TokenKind::Slash => add_binary_op(&mut stack, BinOp::Div)?,
       TokenKind::Gt => add_binary_op(&mut stack, BinOp::Gt)?,
+      TokenKind::Gte => add_binary_op(&mut stack, BinOp::Gte)?,
       TokenKind::Lt => add_binary_op(&mut stack, BinOp::Lt)?,
+      TokenKind::Lte => add_binary_op(&mut stack, BinOp::Lte)?,
       TokenKind::Eq => add_binary_op(&mut stack, BinOp::Eq)?,
       TokenKind::Percent => add_binary_op(&mut stack, BinOp::Rem)?,
       TokenKind::Question => {
@@ -414,6 +416,16 @@ mod tests {
   #[rstest]
   fn test_eq_op() {
     assert_yaml_snapshot!(parse_expr("x y =").unwrap());
+  }
+
+  #[rstest]
+  fn test_gte_op() {
+    assert_yaml_snapshot!(parse_expr("x y >=").unwrap());
+  }
+
+  #[rstest]
+  fn test_lte_op() {
+    assert_yaml_snapshot!(parse_expr("x y <=").unwrap());
   }
 
   #[rstest]

--- a/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__gte_op.snap
+++ b/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__gte_op.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cranexpr-parser/src/lib.rs
+expression: "parse_expr(\"x y >=\").unwrap()"
+---
+- Binary:
+    - Gte
+    - Ident: x
+    - Ident: y

--- a/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__lte_op.snap
+++ b/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__lte_op.snap
@@ -1,0 +1,8 @@
+---
+source: crates/cranexpr-parser/src/lib.rs
+expression: "parse_expr(\"x y <=\").unwrap()"
+---
+- Binary:
+    - Lte
+    - Ident: x
+    - Ident: y

--- a/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__xor.snap
+++ b/crates/cranexpr-parser/src/snapshots/cranexpr_parser__tests__xor.snap
@@ -1,0 +1,14 @@
+---
+source: crates/cranexpr-parser/src/lib.rs
+expression: "parse_expr(\"x 0 > y 0 > xor\").unwrap()"
+---
+- Binary:
+    - Xor
+    - Binary:
+        - Gt
+        - Ident: x
+        - Lit: 0
+    - Binary:
+        - Gt
+        - Ident: y
+        - Lit: 0


### PR DESCRIPTION
With these three done, we should have parity with `std.Expr`.