### PR TITLE
plugin: add `Select` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,37 @@ cranexpr.Expr(
 - `format` — By default the output format is the same as the first input clip's
   format. This can be overridden by setting this parameter.
 - `boundary` — Boundary mode. `0` for clamping, `1` for mirroring.
+
+```python
+cranexpr.Select(
+  clip_src: vs.VideoNode | Sequence[vs.VideoNode],
+  prop_src: vs.VideoNode | Sequence[vs.VideoNode],
+  expr: str | list[str],
+) -> vs.VideoNode
+```
+
+- `clip_src` — Candidate clips. All must have the same format and dimensions.
+- `prop_src` — Clips whose frame properties the expression may read.
+- `expr` — Reverse Polish Notation (RPN) expression(s) for each plane. The
+  expression given for the previous plane is used if the list contains fewer
+  expressions than the input clip has planes. This means that a single
+  expression will be applied to all planes by default.
+
+`Select` evaluates a RPN expression once per frame (per plane) and uses the
+result as an index to pick a clip from `clip_src` to satisfy the current frame
+request. It is designed to replace many uses of `std.FrameEval` where you want
+to compute a metric from frame properties and then choose one of several clips
+to use.
+
+For each output frame and each plane, the filter evaluates the plane's
+expression, rounds the result to the nearest integer, clamps it to the range
+`[0, len(clip_src) - 1]`, then takes that plane from `clip_src[index]`'s frame
+`n`.
+
+`Select` supports all operators supported by `Expr` except those that access
+pixel values (`x`/`y`/`srcN` as pixel values, relative pixel access like
+`x[-1,0]`, absolute pixel access like `x[]`, and the per-pixel coordinate
+variables `X` and `Y`).
+
+Unlike `Expr`, where a non-existent frame property evaluates to `NaN`, `Select`
+uses `0.0` instead.

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -15,6 +15,7 @@ use cranexpr_ast::{BoundaryMode, Expr};
 use nanoid::nanoid;
 
 use crate::MainFunction;
+use crate::SelectFunction;
 use crate::comment_writer::CommentWriter;
 use crate::component_type::ComponentType;
 use crate::errors::{CodegenError, CodegenResult};
@@ -162,6 +163,45 @@ pub fn compile_clif(
   decorate_function(&mut built.comments, &mut output, &built.ctx.func)
     .map_err(|err| CodegenError::CompilationError(err.to_string()))?;
   Ok(output)
+}
+
+/// Compiles an expression AST into a JIT-compiled function that evaluates the
+/// expression once.
+///
+/// The expression must not reference any pixel-access identifiers, relative or
+/// absolute pixel access, nor per-pixel context variables. Callers should
+/// validate this via something like [`PixelAccessVisitor`] prior to compilation.
+///
+/// The `num_prop_clips` argument is the number of input clips from which
+/// frame properties may be drawn.
+///
+/// # Errors
+///
+/// Returns a [`CodegenError`] if the expression cannot be compiled.
+///
+/// # Panics
+///
+/// Panics if JIT finalization fails.
+pub fn compile_jit_select(
+  ast: &[Expr],
+  num_prop_clips: usize,
+  required_frame_props: &[(usize, String)],
+) -> Result<SelectFunction, CodegenError> {
+  let mut jit_module = create_jit_module();
+  let mut built = build_select_fn(&mut jit_module, ast, num_prop_clips, required_frame_props)?;
+
+  if let Err(err) = jit_module.define_function(built.func_id, &mut built.ctx) {
+    let err_msg = match err {
+      ModuleError::Compilation(source) => pretty_error(&built.ctx.func, source),
+      _ => err.to_string(),
+    };
+    return Err(CodegenError::CompilationError(err_msg));
+  }
+
+  jit_module.finalize_definitions().unwrap();
+
+  let finalized = jit_module.get_finalized_function(built.func_id);
+  Ok(SelectFunction::from_ptr(finalized))
 }
 
 fn build_entry_fn(
@@ -313,6 +353,115 @@ fn build_entry_fn(
     })?;
 
     fx.bcx.ins().return_(&[]);
+    fx.bcx.seal_all_blocks();
+    fx.bcx.finalize();
+    comments = fx.comments;
+  }
+
+  Ok(BuiltEntryFn {
+    func_id: main_func_id,
+    ctx,
+    comments,
+  })
+}
+
+fn build_select_fn(
+  m: &mut dyn Module,
+  ast: &[Expr],
+  num_prop_clips: usize,
+  required_frame_props: &[(usize, String)],
+) -> CodegenResult<BuiltEntryFn> {
+  let pointer_type = m.target_config().pointer_type();
+
+  let main_sig = Signature {
+    params: vec![
+      AbiParam::new(types::I64),   // Current frame number (N).
+      AbiParam::new(types::I64),   // Clip width.
+      AbiParam::new(types::I64),   // Clip height.
+      AbiParam::new(pointer_type), // Frame properties array pointer.
+    ],
+    returns: vec![AbiParam::new(types::F32)],
+    call_conv: m.target_config().default_call_conv,
+  };
+  let main_func_id = m
+    .declare_function(
+      &format!("__CRANEXPR_SELECT_{}", nanoid!()),
+      Linkage::Export,
+      &main_sig,
+    )
+    .unwrap();
+
+  let mut ctx = Context::new();
+  ctx.func.signature = main_sig;
+  let comments;
+  {
+    let mut func_ctx = FunctionBuilderContext::new();
+    let mut bcx = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+
+    let block = bcx.create_block();
+    bcx.switch_to_block(block);
+    bcx.append_block_params_for_function_params(block);
+
+    let (n, width, height, props_ptr) = {
+      let params = bcx.block_params(block);
+      (params[0], params[1], params[2], params[3])
+    };
+
+    // The actual types are not relevant here because pixel access is not
+    // permitted anyways.
+    let src_types = vec![ComponentType::F32; num_prop_clips];
+
+    let mut fx = FunctionCx {
+      module: m,
+      bcx,
+      variables: HashMap::new(),
+      user_variables: HashMap::new(),
+      dst_type: ComponentType::F32,
+      src_types,
+      pointer_type,
+      boundary_mode: BoundaryMode::Clamp,
+      src_clips: Pointer::new(props_ptr),
+      src_strides: Pointer::new(props_ptr),
+      width,
+      height,
+      comments: CommentWriter::new(),
+      cache: HashMap::new(),
+    };
+
+    // Constants.
+    codegen_variable(&mut fx, "N", n);
+    codegen_variable(&mut fx, "width", width);
+    codegen_variable(&mut fx, "height", height);
+    let pi_val = fx.bcx.ins().f32const(PI);
+    codegen_variable(&mut fx, "pi", pi_val);
+
+    // Frame properties.
+    let props_ptr = Pointer::new(props_ptr);
+    for (i, (clip_idx, prop_name)) in required_frame_props.iter().enumerate() {
+      let offset = Offset32::new((i * size_of::<f32>()) as i32);
+      let val = props_ptr
+        .offset(&mut fx, offset)
+        .load(&mut fx, types::F32, FRAME_PROP_MEMFLAGS);
+
+      let var = fx.bcx.declare_var(types::F32);
+      fx.bcx.def_var(var, val);
+
+      fx.variables
+        .insert(format!("prop_{clip_idx}_{prop_name}"), var);
+    }
+
+    // Evaluate expressions.
+    let expr_val = if let Some((last_expr, preceding_exprs)) = ast.split_last() {
+      for expr in preceding_exprs {
+        translate_expr_simd(&mut fx, expr)?;
+      }
+      translate_expr_simd(&mut fx, last_expr)?
+    } else {
+      return Err(cranexpr_parser::ParseError::ExpressionEvaluatesToNothing.into());
+    };
+
+    let scalar = fx.bcx.ins().extractlane(expr_val, 0);
+    fx.bcx.ins().return_(&[scalar]);
     fx.bcx.seal_all_blocks();
     fx.bcx.finalize();
     comments = fx.comments;
@@ -1593,5 +1742,70 @@ mod tests {
 
     let out: Vec<u16> = dst_flat[..width].to_vec();
     assert_eq!(out, vec![110, 220, 330, 440, 550, 660, 770, 880]);
+  }
+
+  fn run_select(expr: &str, n: i32) -> f32 {
+    let ast = cranexpr_parser::parse_expr(expr).unwrap();
+    let compiled = compile_jit_select(&ast, 0, &[]).expect("should compile select");
+    unsafe { compiled.invoke(n, 1, 1, &[]) }
+  }
+
+  fn run_select_with_props(
+    expr: &str,
+    n: i32,
+    num_prop_clips: usize,
+    required_props: &[(usize, String)],
+    frame_props: &[f32],
+  ) -> f32 {
+    let ast = cranexpr_parser::parse_expr(expr).unwrap();
+    let compiled =
+      compile_jit_select(&ast, num_prop_clips, required_props).expect("should compile select");
+    unsafe { compiled.invoke(n, 1, 1, frame_props) }
+  }
+
+  #[rstest]
+  #[case("0", 0, 0.0)]
+  #[case("1", 0, 1.0)]
+  #[case("N", 0, 0.0)]
+  #[case("N", 7, 7.0)]
+  #[case("N 1 +", 5, 6.0)]
+  #[case("1 2 +", 0, 3.0)]
+  #[case("pi", 0, PI)]
+  fn test_select_basic(#[case] expr: &str, #[case] n: i32, #[case] expected: f32) {
+    assert_relative_eq!(run_select(expr, n), expected);
+  }
+
+  #[rstest]
+  fn test_select_frame_props() {
+    let required = vec![
+      (0, "PlaneStatsAverage".to_string()),
+      (1, "PlaneStatsAverage".to_string()),
+    ];
+    let expr = "x.PlaneStatsAverage y.PlaneStatsAverage >";
+    let result = run_select_with_props(expr, 0, 2, &required, &[0.7, 0.3]);
+    assert_relative_eq!(result, 1.0);
+    let result = run_select_with_props(expr, 0, 2, &required, &[0.1, 0.9]);
+    assert_relative_eq!(result, 0.0);
+  }
+
+  #[rstest]
+  fn test_select_width_height() {
+    let ast = cranexpr_parser::parse_expr("width height *").unwrap();
+    let compiled = compile_jit_select(&ast, 0, &[]).expect("should compile select");
+    let result = unsafe { compiled.invoke(0, 640, 480, &[]) };
+    assert_relative_eq!(result, 640.0 * 480.0);
+  }
+
+  #[rstest]
+  fn test_select_width_height_individually() {
+    let ast = cranexpr_parser::parse_expr("width").unwrap();
+    let compiled = compile_jit_select(&ast, 0, &[]).expect("should compile select");
+    let result = unsafe { compiled.invoke(0, 1920, 1080, &[]) };
+    assert_relative_eq!(result, 1920.0);
+
+    let ast = cranexpr_parser::parse_expr("height").unwrap();
+    let compiled = compile_jit_select(&ast, 0, &[]).expect("should compile select");
+    let result = unsafe { compiled.invoke(0, 1920, 1080, &[]) };
+    assert_relative_eq!(result, 1080.0);
   }
 }

--- a/crates/cranexpr-codegen/src/lib.rs
+++ b/crates/cranexpr-codegen/src/lib.rs
@@ -8,10 +8,12 @@ mod pointer;
 mod translate;
 mod translate_simd;
 
-pub use compiler::{compile_clif, compile_jit};
+pub use compiler::{compile_clif, compile_jit, compile_jit_select};
 
 type MainFunc =
   unsafe extern "C" fn(*mut u8, i64, *const *const u8, *const i64, i64, i64, i64, *const f32);
+
+type SelectFunc = unsafe extern "C" fn(i64, i64, i64, *const f32) -> f32;
 
 #[derive(Debug)]
 pub struct MainFunction {
@@ -65,5 +67,43 @@ impl MainFunction {
         frame_props_ptr,
       );
     };
+  }
+}
+
+/// A JIT-compiled function that evaluates an expression once per frame.
+#[derive(Debug)]
+pub struct SelectFunction {
+  ptr: *const u8,
+}
+
+impl SelectFunction {
+  pub(crate) const fn from_ptr(ptr: *const u8) -> Self {
+    Self { ptr }
+  }
+
+  /// Invokes the compiled select function.
+  ///
+  /// # Safety
+  ///
+  /// The caller must ensure that `frame_props` matches what was used during
+  /// compilation.
+  #[inline]
+  #[must_use]
+  pub unsafe fn invoke(&self, n: i32, width: i32, height: i32, frame_props: &[f32]) -> f32 {
+    let frame_props_ptr = if frame_props.is_empty() {
+      std::ptr::null()
+    } else {
+      frame_props.as_ptr()
+    };
+
+    let func = unsafe { std::mem::transmute::<*const u8, SelectFunc>(self.ptr) };
+    unsafe {
+      func(
+        i64::from(n),
+        i64::from(width),
+        i64::from(height),
+        frame_props_ptr,
+      )
+    }
   }
 }

--- a/crates/cranexpr-transforms/src/errors.rs
+++ b/crates/cranexpr-transforms/src/errors.rs
@@ -10,4 +10,7 @@ use thiserror::Error;
 pub enum TransformError {
   #[error("Invalid clip identifier '{0}'.")]
   InvalidClipIdentifier(String),
+
+  #[error("Pixel access and per-pixel context are not allowed here: '{0}'.")]
+  PixelAccessNotAllowed(String),
 }

--- a/crates/cranexpr-transforms/src/lib.rs
+++ b/crates/cranexpr-transforms/src/lib.rs
@@ -1,9 +1,11 @@
 //! AST traversal patterns, optimizations, and rewrites.
 
 mod errors;
+mod pixel_access_visitor;
 mod prop_visitor;
 mod visit;
 
 pub use errors::TransformError;
+pub use pixel_access_visitor::PixelAccessVisitor;
 pub use prop_visitor::PropVisitor;
 pub use visit::{Visitor, walk_expr};

--- a/crates/cranexpr-transforms/src/pixel_access_visitor.rs
+++ b/crates/cranexpr-transforms/src/pixel_access_visitor.rs
@@ -1,0 +1,157 @@
+use cranexpr_ast::Expr;
+
+use crate::errors::TransformError;
+use crate::visit::{Visitor, walk_expr};
+
+fn is_clip_identifier(name: &str) -> bool {
+  matches!(name.as_bytes(), [b'a'..=b'z'])
+    || name
+      .strip_prefix("src")
+      .is_some_and(|s| s.parse::<usize>().is_ok())
+}
+
+fn is_pixel_context_identifier(name: &str) -> bool {
+  matches!(name, "X" | "Y")
+}
+
+/// Visitor that rejects any expression node that would require access to
+/// pixel data or per-pixel context.
+pub struct PixelAccessVisitor {
+  pub error: Option<TransformError>,
+}
+
+impl PixelAccessVisitor {
+  #[must_use]
+  pub const fn new() -> Self {
+    Self { error: None }
+  }
+}
+
+impl Default for PixelAccessVisitor {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<'a> Visitor<'a> for PixelAccessVisitor {
+  fn visit_expr(&mut self, expr: &'a Expr) {
+    if self.error.is_some() {
+      return;
+    }
+
+    match expr {
+      Expr::RelAccess { clip, .. } => {
+        self.error = Some(TransformError::PixelAccessNotAllowed(format!(
+          "{clip}[...]"
+        )));
+      }
+      Expr::AbsAccess { clip, .. } => {
+        self.error = Some(TransformError::PixelAccessNotAllowed(format!("{clip}[]")));
+      }
+      Expr::Ident(name) | Expr::Load(name) => {
+        if is_clip_identifier(name) || is_pixel_context_identifier(name) {
+          self.error = Some(TransformError::PixelAccessNotAllowed(name.clone()));
+          return;
+        }
+        walk_expr(self, expr);
+      }
+      _ => walk_expr(self, expr),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use super::*;
+
+  #[test]
+  fn test_rejects_clip_shorthand() {
+    let ast = Expr::Ident("x".to_string());
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+
+    let ast = Expr::Ident("src0".to_string());
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+
+    let ast = Expr::Ident("a".to_string());
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+  }
+
+  #[test]
+  fn test_rejects_pixel_context_identifiers() {
+    for name in ["X", "Y"] {
+      let ast = Expr::Ident(name.to_string());
+      let mut v = PixelAccessVisitor::new();
+      v.visit_expr(&ast);
+      assert!(v.error.is_some(), "expected error for {name}");
+    }
+  }
+
+  #[test]
+  fn test_rejects_rel_access() {
+    let ast = Expr::RelAccess {
+      clip: "x".to_string(),
+      rel_x: -1,
+      rel_y: 0,
+      boundary_mode: None,
+    };
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+  }
+
+  #[test]
+  fn test_rejects_abs_access() {
+    let ast = Expr::AbsAccess {
+      clip: "x".to_string(),
+      x: Arc::new(Expr::Lit(0.0)),
+      y: Arc::new(Expr::Lit(0.0)),
+      boundary_mode: None,
+    };
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+  }
+
+  #[test]
+  fn test_allows_frame_prop_access() {
+    let ast = Expr::Prop("x".to_string(), "PlaneStatsAverage".to_string());
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_none());
+  }
+
+  #[test]
+  fn test_allows_n_and_pi_and_literals() {
+    for name in ["N", "pi", "width", "height"] {
+      let ast = Expr::Ident(name.to_string());
+      let mut v = PixelAccessVisitor::new();
+      v.visit_expr(&ast);
+      assert!(v.error.is_none(), "unexpected error for {name}");
+    }
+
+    let ast = Expr::Lit(1.5);
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_none());
+  }
+
+  #[test]
+  fn test_recurses_into_children() {
+    let ast = Expr::Binary(
+      cranexpr_ast::BinOp::Add,
+      Arc::new(Expr::Lit(1.0)),
+      Arc::new(Expr::Ident("x".to_string())),
+    );
+    let mut v = PixelAccessVisitor::new();
+    v.visit_expr(&ast);
+    assert!(v.error.is_some());
+  }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,18 @@ pub enum CranexprError {
   #[error(transparent)]
   Codegen(#[from] cranexpr_codegen::errors::CodegenError),
 
+  #[error("Clips in clip_src differ in format or dimensions.")]
+  ClipSrcMismatch,
+
+  #[error("clip_src must not be empty.")]
+  EmptyClipSrc,
+
+  #[error("prop_src must not be empty.")]
+  EmptyPropSrc,
+
+  #[error("At least one expression is required.")]
+  NoExpression,
+
   #[error("Invalid frame property name '{0}'.")]
   InvalidFramePropertyName(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 mod component_type;
 mod errors;
 mod expr;
+mod select;
 
 use vapoursynth4_rs::declare_plugin;
 
 use crate::expr::CranexprFilter;
+use crate::select::SelectFilter;
 
 declare_plugin!(
   c"sgt.cranexpr",
@@ -13,5 +15,6 @@ declare_plugin!(
   (0, 6),
   VAPOURSYNTH_API_VERSION,
   0,
-  (CranexprFilter, None)
+  (CranexprFilter, None),
+  (SelectFilter, None)
 );

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,0 +1,340 @@
+use std::{
+  ffi::{CStr, c_void},
+  ptr,
+};
+
+use const_str::cstr;
+use vapoursynth4_rs::{
+  VideoInfo,
+  core::CoreRef,
+  ffi::VSFrame,
+  frame::{Frame, FrameContext, VideoFrame},
+  key,
+  map::{Key, MapRef},
+  node::{
+    ActivationReason, Dependencies, Filter, FilterDependency, Node, RequestPattern, VideoNode,
+  },
+  utils::{is_constant_video_format, is_same_video_info},
+};
+
+use cranexpr_codegen::{SelectFunction, compile_jit_select};
+use cranexpr_transforms::{PixelAccessVisitor, PropVisitor, Visitor};
+
+use crate::errors::CranexprError;
+
+pub(crate) struct SelectFilter {
+  clip_nodes: Vec<VideoNode>,
+  prop_nodes: Vec<VideoNode>,
+  vi: VideoInfo,
+  bytecode: Vec<SelectFunction>,
+  required_frame_props: Vec<Vec<(usize, String)>>,
+  frame_prop_keys: Vec<Vec<Key>>,
+}
+
+struct FrameState {
+  indices: Vec<i32>,
+}
+
+fn read_frame_prop(frame: &VideoFrame, key: &Key) -> f32 {
+  if let Some(props) = frame.properties() {
+    if let Ok(float_val) = props.get_float(key, 0) {
+      return float_val as f32;
+    }
+    if let Ok(int_val) = props.get_int(key, 0) {
+      #[allow(clippy::cast_precision_loss)]
+      return int_val as f32;
+    }
+    if let Ok(bin_val) = props.get_binary(key, 0)
+      && !bin_val.is_empty()
+    {
+      return f32::from(bin_val[0]);
+    }
+  }
+  0.0
+}
+
+impl SelectFilter {
+  fn compute_indices(&self, n: i32, prop_frames: &[VideoFrame]) -> Vec<i32> {
+    let num_clips = self.clip_nodes.len() as i32;
+    let num_planes = self.vi.format.num_planes as usize;
+    let mut indices = Vec::with_capacity(num_planes);
+
+    // akarin.Select uses the clip's dimensions rather than the plane's
+    // dimensions like Expr does. Not sure if this is intentional or not.
+    let width = self.vi.width;
+    let height = self.vi.height;
+
+    for plane in 0..num_planes {
+      let required = &self.required_frame_props[plane];
+      let keys = &self.frame_prop_keys[plane];
+
+      let mut props = Vec::with_capacity(required.len());
+      for (i, (clip_idx, _)) in required.iter().enumerate() {
+        let frame = &prop_frames[*clip_idx];
+        let key = &keys[i];
+        props.push(read_frame_prop(frame, key));
+      }
+
+      let raw = unsafe { self.bytecode[plane].invoke(n, width, height, &props) };
+      let rounded = raw.round();
+      #[allow(clippy::cast_precision_loss)]
+      let max_f = (num_clips - 1) as f32;
+      let idx = if rounded.is_nan() || rounded <= 0.0 {
+        0
+      } else if rounded >= max_f {
+        num_clips - 1
+      } else {
+        rounded as i32
+      };
+      indices.push(idx);
+    }
+
+    indices
+  }
+}
+
+impl Filter for SelectFilter {
+  type Error = CranexprError;
+  type FrameType = VideoFrame;
+  type FilterData = ();
+
+  const NAME: &'static CStr = cstr!("Select");
+  const ARGS: &'static CStr = cstr!("clip_src:vnode[];prop_src:vnode[];expr:data[];");
+  const RETURN_TYPE: &'static CStr = cstr!("clip:vnode;");
+
+  #[inline]
+  fn create(
+    input: MapRef<'_>,
+    output: MapRef<'_>,
+    _data: Option<Box<Self::FilterData>>,
+    mut core: CoreRef<'_>,
+  ) -> Result<(), Self::Error> {
+    let Some(num_clip_src) = input.num_elements(key!(c"clip_src")) else {
+      return Err(CranexprError::EmptyClipSrc);
+    };
+    if num_clip_src == 0 {
+      return Err(CranexprError::EmptyClipSrc);
+    }
+
+    let clip_nodes = (0..num_clip_src)
+      .map(|i| input.get_video_node(key!(c"clip_src"), i).unwrap())
+      .collect::<Vec<_>>();
+
+    let Some(num_prop_src) = input.num_elements(key!(c"prop_src")) else {
+      return Err(CranexprError::EmptyPropSrc);
+    };
+    if num_prop_src == 0 {
+      return Err(CranexprError::EmptyPropSrc);
+    }
+
+    let prop_nodes = (0..num_prop_src)
+      .map(|i| input.get_video_node(key!(c"prop_src"), i).unwrap())
+      .collect::<Vec<_>>();
+
+    for node in &clip_nodes {
+      if !is_constant_video_format(node.info()) {
+        return Err(CranexprError::VariableFormat);
+      }
+    }
+    for node in &prop_nodes {
+      if !is_constant_video_format(node.info()) {
+        return Err(CranexprError::VariableFormat);
+      }
+    }
+
+    let vi = clip_nodes[0].info().clone();
+    for node in clip_nodes.iter().skip(1) {
+      let other = node.info();
+      if !is_same_video_info(&vi, other) {
+        return Err(CranexprError::ClipSrcMismatch);
+      }
+    }
+
+    let num_exprs = input.num_elements(key!(c"expr")).unwrap_or(0);
+    if num_exprs == 0 {
+      return Err(CranexprError::NoExpression);
+    }
+    if num_exprs > vi.format.num_planes {
+      return Err(CranexprError::MoreExpressionsThanPlanes);
+    }
+
+    let num_planes = vi.format.num_planes as usize;
+    let mut expr = vec![""; num_planes];
+    for i in 0..num_exprs {
+      expr[i as usize] = input.get_utf8(key!(c"expr"), i).unwrap();
+    }
+    // Fill the rest of the exprs with the last specified one.
+    for i in (num_exprs as usize)..num_planes {
+      expr[i] = expr[num_exprs as usize - 1];
+    }
+
+    let mut bytecode = Vec::with_capacity(num_planes);
+    let mut required_frame_props: Vec<Vec<(usize, String)>> = Vec::with_capacity(num_planes);
+    let mut frame_prop_keys: Vec<Vec<Key>> = Vec::with_capacity(num_planes);
+
+    for plane_expr in &expr {
+      let ast = cranexpr_parser::parse_expr(plane_expr)?;
+
+      let mut pa_visitor = PixelAccessVisitor::new();
+      for node in &ast {
+        pa_visitor.visit_expr(node);
+      }
+      if let Some(err) = pa_visitor.error {
+        return Err(err.into());
+      }
+
+      let mut prop_visitor = PropVisitor::new(prop_nodes.len());
+      for node in &ast {
+        prop_visitor.visit_expr(node);
+      }
+      if let Some(err) = prop_visitor.error {
+        return Err(err.into());
+      }
+
+      let required: Vec<(usize, String)> = prop_visitor.props.into_iter().collect();
+      let mut keys = Vec::with_capacity(required.len());
+      for (_, prop_name) in &required {
+        keys.push(
+          Key::new(prop_name.as_str())
+            .map_err(|_| CranexprError::InvalidFramePropertyName(prop_name.clone()))?,
+        );
+      }
+
+      bytecode.push(compile_jit_select(&ast, prop_nodes.len(), &required)?);
+      required_frame_props.push(required);
+      frame_prop_keys.push(keys);
+    }
+
+    let mut deps: Vec<FilterDependency> = Vec::with_capacity(clip_nodes.len() + prop_nodes.len());
+    for node in &clip_nodes {
+      deps.push(FilterDependency {
+        source: node.as_ptr(),
+        request_pattern: if vi.num_frames <= node.info().num_frames {
+          RequestPattern::StrictSpatial
+        } else {
+          RequestPattern::General
+        },
+      });
+    }
+    for node in &prop_nodes {
+      deps.push(FilterDependency {
+        source: node.as_ptr(),
+        request_pattern: if vi.num_frames <= node.info().num_frames {
+          RequestPattern::StrictSpatial
+        } else {
+          RequestPattern::General
+        },
+      });
+    }
+
+    let filter = Self {
+      clip_nodes,
+      prop_nodes,
+      vi: vi.clone(),
+      bytecode,
+      required_frame_props,
+      frame_prop_keys,
+    };
+
+    core.create_video_filter(
+      output,
+      cstr!("Select"),
+      &vi,
+      Box::new(filter),
+      Dependencies::new(&deps).unwrap(),
+    );
+
+    Ok(())
+  }
+
+  #[inline]
+  fn get_frame(
+    &self,
+    n: i32,
+    activation_reason: ActivationReason,
+    frame_data: *mut *mut c_void,
+    mut ctx: FrameContext,
+    core: CoreRef<'_>,
+  ) -> Result<Option<VideoFrame>, Self::Error> {
+    match activation_reason {
+      ActivationReason::Initial => {
+        for node in &self.prop_nodes {
+          ctx.request_frame_filter(n, node);
+        }
+        Ok(None)
+      }
+      ActivationReason::AllFramesReady => {
+        let state_ptr = unsafe { *frame_data }.cast::<FrameState>();
+        if state_ptr.is_null() {
+          // First pass: evaluate expressions and request the selected clips.
+          let prop_frames = self
+            .prop_nodes
+            .iter()
+            .map(|node| node.get_frame_filter(n, &mut ctx))
+            .collect::<Vec<_>>();
+
+          let indices = self.compute_indices(n, &prop_frames);
+
+          // Request each unique selected clip index once.
+          let mut requested = vec![false; self.clip_nodes.len()];
+          for &idx in &indices {
+            let uidx = idx as usize;
+            if !requested[uidx] {
+              requested[uidx] = true;
+              ctx.request_frame_filter(n, &self.clip_nodes[uidx]);
+            }
+          }
+
+          let state = Box::new(FrameState { indices });
+          unsafe {
+            *frame_data = Box::into_raw(state).cast::<c_void>();
+          }
+          return Ok(None);
+        }
+
+        // Second pass: all requested clip frames are ready.
+        let state = unsafe { Box::from_raw(state_ptr) };
+        unsafe {
+          *frame_data = ptr::null_mut();
+        }
+        let indices = state.indices;
+
+        // Fetch one frame per plane.
+        let num_planes = self.vi.format.num_planes as usize;
+        let plane_frames: Vec<VideoFrame> = indices
+          .iter()
+          .take(num_planes)
+          .map(|&idx| self.clip_nodes[idx as usize].get_frame_filter(n, &mut ctx))
+          .collect();
+
+        let plane_src_ptrs: Vec<*const VSFrame> = plane_frames
+          .iter()
+          .map(|f| f.as_ptr().cast_const())
+          .collect();
+        let plane_src_indices: Vec<i32> = (0..num_planes as i32).collect();
+
+        let dst = core.new_video_frame2(
+          &self.vi.format,
+          self.vi.width,
+          self.vi.height,
+          &plane_src_ptrs,
+          &plane_src_indices,
+          Some(&plane_frames[0]),
+        );
+
+        Ok(Some(dst))
+      }
+      ActivationReason::Error => {
+        let state_ptr = unsafe { *frame_data }.cast::<FrameState>();
+        if !state_ptr.is_null() {
+          // Drop the state.
+          let _ = unsafe { Box::from_raw(state_ptr) };
+          unsafe {
+            *frame_data = ptr::null_mut();
+          }
+        }
+        Ok(None)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Intended to mirror `akarin.Select` as an alternative to `std.FrameEval`.

`Select` compiles a per-plane RPN expression once, evaluates it per frame (rather than per pixel like `Expr`), and uses the result as an index into `clip_src` to satisfy the current frame request. Clip variables resolve to the corresponding `prop_src` entry for frame properties.

All operators from `Expr` are supported except those that access pixel values or per-pixel context.

Unlike `Expr`, a non-existent frame property evaluates to `0.0` rather than `NaN`.