### PR TITLE
codegen: separate user variables from builtin globals

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -30,6 +30,9 @@ pub(crate) struct FunctionCx<'m, 'clif> {
   pub(crate) bcx: FunctionBuilder<'clif>,
   pub(crate) variables: HashMap<String, Variable>,
 
+  /// User-defined variables created by the `var!` store expression.
+  pub(crate) user_variables: HashMap<String, Variable>,
+
   #[allow(dead_code)]
   pub(crate) dst_type: ComponentType,
   #[allow(dead_code)]
@@ -213,6 +216,7 @@ fn build_entry_fn(
       module: m,
       bcx,
       variables: HashMap::new(),
+      user_variables: HashMap::new(),
       dst_type,
       src_types: src_types.to_vec(),
       pointer_type,

--- a/crates/cranexpr-codegen/src/translate.rs
+++ b/crates/cranexpr-codegen/src/translate.rs
@@ -87,9 +87,8 @@ pub(crate) fn translate_expr(
       })
     }
 
-    // TODO: globals and user variables should reference different underlying
-    // storage.
-    Expr::Ident(name) | Expr::Load(name) => {
+    // Globals.
+    Expr::Ident(name) => {
       let variable = if let Ok(clip_idx) = resolve_clip_name(name, &fx.src_types) {
         fx.variables.get(&format!("src{clip_idx}"))
       } else {
@@ -105,16 +104,25 @@ pub(crate) fn translate_expr(
       })
     }
 
+    // User variables.
+    Expr::Load(name) => {
+      let variable = fx
+        .user_variables
+        .get(name)
+        .ok_or_else(|| CodegenError::UndefinedVariable(name.clone()))?;
+      Ok(fx.bcx.use_var(*variable))
+    }
+
     Expr::IfElse(condition, then_body, else_body) => {
       translate_if_else(fx, condition, then_body, else_body)
     }
     Expr::Store(name, expr) => {
       let value = translate_expr(fx, expr)?;
-      let variable = if let Some(variable) = fx.variables.get(name) {
+      let variable = if let Some(variable) = fx.user_variables.get(name) {
         *variable
       } else {
         let var = fx.bcx.declare_var(types::F32);
-        fx.variables.insert(name.clone(), var);
+        fx.user_variables.insert(name.clone(), var);
         var
       };
       fx.bcx.def_var(variable, value);


### PR DESCRIPTION
Previously, both builtins and user variables shared a single `HashMap`, so e.g. `8 N!` would overwrite the frame number builtin's Cranelift `Variable`. Since the frame number `N` is declared as `i64`, but store values are `f32`, this would cause a panic.

Give user variables their own namespace.