### PR TITLE
codegen: vectorize `exp` in the SIMD path

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -653,6 +653,15 @@ mod tests {
   }
 
   #[rstest]
+  fn test_exp_per_lane() {
+    let src: &[&[f32]] = &[&[-2.0, -0.5, 0.5, 2.0]];
+    let out = run_expr_padded("x exp", src, None);
+    for (i, &v) in src[0].iter().enumerate() {
+      assert_relative_eq!(out[0][i], v.exp(), epsilon = 5e-6);
+    }
+  }
+
+  #[rstest]
   fn test_variables() {
     let ast = cranexpr_parser::parse_expr("x y +").unwrap();
     let compiled = compile_jit(

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -91,5 +91,6 @@ const fn is_unop_simd_eligible(op: UnOp) -> bool {
       | UnOp::Trunc
       | UnOp::Sine
       | UnOp::Cosine
+      | UnOp::Exp
   )
 }

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -81,7 +81,8 @@ pub(crate) fn translate_expr_simd(
         }
         UnOp::Sine => sin_cos_simd(fx, x, SinCos::Sin),
         UnOp::Cosine => sin_cos_simd(fx, x, SinCos::Cos),
-        UnOp::Exp | UnOp::Log | UnOp::Round | UnOp::Tangent => {
+        UnOp::Exp => exp_simd(fx, x),
+        UnOp::Log | UnOp::Round | UnOp::Tangent => {
           unreachable!("op {op:?} should have been rejected by SIMD eligibility check")
         }
       })


### PR DESCRIPTION
We already had `exp_simd` implemented. Now it's wired up to `UnOp::Exp`.