### PR TITLE
codegen: vectorize `log` in the SIMD path

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -746,6 +746,15 @@ mod tests {
   }
 
   #[rstest]
+  fn test_log_per_lane() {
+    let src: &[&[f32]] = &[&[0.5, 1.0, 2.718_281_8, 10.0]];
+    let out = run_expr_padded("x log", src, None);
+    for (i, &v) in src[0].iter().enumerate() {
+      assert_relative_eq!(out[0][i], v.ln(), epsilon = 5e-6);
+    }
+  }
+
+  #[rstest]
   #[case("1.2 floor", 1.0)]
   #[case("1.8 floor", 1.0)]
   #[case("-1.2 floor", -2.0)]

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -92,5 +92,6 @@ const fn is_unop_simd_eligible(op: UnOp) -> bool {
       | UnOp::Sine
       | UnOp::Cosine
       | UnOp::Exp
+      | UnOp::Log
   )
 }

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -82,7 +82,8 @@ pub(crate) fn translate_expr_simd(
         UnOp::Sine => sin_cos_simd(fx, x, SinCos::Sin),
         UnOp::Cosine => sin_cos_simd(fx, x, SinCos::Cos),
         UnOp::Exp => exp_simd(fx, x),
-        UnOp::Log | UnOp::Round | UnOp::Tangent => {
+        UnOp::Log => log_simd(fx, x),
+        UnOp::Round | UnOp::Tangent => {
           unreachable!("op {op:?} should have been rejected by SIMD eligibility check")
         }
       })


### PR DESCRIPTION
`log_simd` was already present. Wire `UnOp::Log` up to it.