### PR TITLE
codegen: vectorize `round` in the SIMD path

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -858,8 +858,24 @@ mod tests {
   #[case("-1.2 round", -1.0)]
   #[case("-1.8 round", -2.0)]
   #[case("3.0 round", 3.0)]
+  #[case("0.5 round", 0.0)]
+  #[case("1.5 round", 2.0)]
+  #[case("2.5 round", 2.0)]
+  #[case("-0.5 round", 0.0)]
+  #[case("-1.5 round", -2.0)]
+  #[case("-2.5 round", -2.0)]
   fn test_round(#[case] expr: &str, #[case] expected: f32) {
     assert_relative_eq!(run_expr(expr), expected);
+  }
+
+  #[rstest]
+  fn test_round_per_lane() {
+    let src: &[&[f32]] = &[&[0.5, 1.5, -0.5, -1.5, 1.2, 1.8, -1.2, -1.8]];
+    let out = run_expr_padded("x round", src, None);
+    let expected = [0.0, 2.0, 0.0, -2.0, 1.0, 2.0, -1.0, -2.0];
+    for (i, &e) in expected.iter().enumerate() {
+      assert_relative_eq!(out[0][i], e);
+    }
   }
 
   #[rstest]

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -88,6 +88,7 @@ const fn is_unop_simd_eligible(op: UnOp) -> bool {
       | UnOp::Not
       | UnOp::BitNot
       | UnOp::Floor
+      | UnOp::Round
       | UnOp::Trunc
       | UnOp::Sine
       | UnOp::Cosine

--- a/crates/cranexpr-codegen/src/translate.rs
+++ b/crates/cranexpr-codegen/src/translate.rs
@@ -55,7 +55,7 @@ pub(crate) fn translate_expr(
         UnOp::Cosine => translate_float_intrinsic_call(fx, "cosf", &[x]),
         UnOp::Exp => translate_float_intrinsic_call(fx, "expf", &[x]),
         UnOp::Floor => fx.bcx.ins().floor(x),
-        UnOp::Round => translate_float_intrinsic_call(fx, "roundf", &[x]),
+        UnOp::Round => fx.bcx.ins().nearest(x),
         UnOp::Log => translate_float_intrinsic_call(fx, "logf", &[x]),
         UnOp::Neg => fx.bcx.ins().fneg(x),
         UnOp::BitNot => {

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -58,6 +58,7 @@ pub(crate) fn translate_expr_simd(
       Ok(match op {
         UnOp::Abs => fx.bcx.ins().fabs(x),
         UnOp::Floor => fx.bcx.ins().floor(x),
+        UnOp::Round => fx.bcx.ins().nearest(x),
         UnOp::Neg => fx.bcx.ins().fneg(x),
         UnOp::Sqrt => fx.bcx.ins().sqrt(x),
         UnOp::Trunc => fx.bcx.ins().trunc(x),
@@ -83,7 +84,7 @@ pub(crate) fn translate_expr_simd(
         UnOp::Cosine => sin_cos_simd(fx, x, SinCos::Cos),
         UnOp::Exp => exp_simd(fx, x),
         UnOp::Log => log_simd(fx, x),
-        UnOp::Round | UnOp::Tangent => {
+        UnOp::Tangent => {
           unreachable!("op {op:?} should have been rejected by SIMD eligibility check")
         }
       })


### PR DESCRIPTION
Also switch the scalar path to `nearest` to match akarin's round-to-nearest, ties-to-even behavior.