### PR TITLE
codegen: vectorize `sgn`

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -887,6 +887,16 @@ mod tests {
   }
 
   #[rstest]
+  fn test_sign_per_lane() {
+    let src: &[&[f32]] = &[&[-2.0, -0.5, -0.0, 0.0, 0.5, 2.0, -100.0, 100.0]];
+    let out = run_expr_padded("x sgn", src, None);
+    let expected = [-1.0, -1.0, 0.0, 0.0, 1.0, 1.0, -1.0, 1.0];
+    for (i, &e) in expected.iter().enumerate() {
+      assert_relative_eq!(out[0][i], e);
+    }
+  }
+
+  #[rstest]
   #[case("3 1 2 sort3 + +", 6.0)]
   #[case("3 1 2 sort3 drop drop", 3.0)]
   #[case("3 1 2 sort3 drop2", 3.0)]

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -86,6 +86,7 @@ const fn is_unop_simd_eligible(op: UnOp) -> bool {
       | UnOp::Neg
       | UnOp::Sqrt
       | UnOp::Not
+      | UnOp::Sign
       | UnOp::BitNot
       | UnOp::Floor
       | UnOp::Round

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -76,9 +76,11 @@ pub(crate) fn translate_expr_simd(
         UnOp::Sign => {
           let zero = splat_f32(fx, 0.0);
           let one = splat_f32(fx, 1.0);
-          let is_zero = fx.bcx.ins().fcmp(FloatCC::Equal, x, zero);
-          let sign = fx.bcx.ins().fcopysign(one, x);
-          vselect_f32x4(fx, is_zero, zero, sign)
+          let neg_one = splat_f32(fx, -1.0);
+          let is_neg = fx.bcx.ins().fcmp(FloatCC::LessThan, x, zero);
+          let is_pos = fx.bcx.ins().fcmp(FloatCC::GreaterThan, x, zero);
+          let pos_or_zero = vselect_f32x4(fx, is_pos, one, zero);
+          vselect_f32x4(fx, is_neg, neg_one, pos_or_zero)
         }
         UnOp::Sine => sin_cos_simd(fx, x, SinCos::Sin),
         UnOp::Cosine => sin_cos_simd(fx, x, SinCos::Cos),


### PR DESCRIPTION
Cranelift does not support `fcopysign` on `f32x4`, so instead we compare against zero to get negative and positive masks, then use two `vselect_f32x4`s to pick between -1.0, 0.0, and 1.0.