### PR TITLE
codegen: vectorize `%`

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -804,6 +804,28 @@ mod tests {
   }
 
   #[rstest]
+  fn test_modulo_per_lane() {
+    let src: &[&[f32]] = &[&[5.0, -5.0, 1.2, 7.5]];
+    let out = run_expr_padded("x 2.0 %", src, None);
+    for (i, &v) in src[0].iter().enumerate() {
+      assert_relative_eq!(out[0][i], v % 2.0, epsilon = 1e-6);
+    }
+
+    let src2: &[&[f32]] = &[&[10.0, -10.0, 13.5, -13.5]];
+    let out2 = run_expr_padded("x -3.0 %", src2, None);
+    for (i, &v) in src2[0].iter().enumerate() {
+      assert_relative_eq!(out2[0][i], v % -3.0, epsilon = 1e-6);
+    }
+
+    let src3: &[&[f32]] = &[&[10.0, 11.0, 12.5, -7.25]];
+    let out3 = run_expr_padded("x X 1 + %", src3, None);
+    for (i, &v) in src3[0].iter().enumerate() {
+      let d = (i as f32) + 1.0;
+      assert_relative_eq!(out3[0][i], v % d, epsilon = 1e-6);
+    }
+  }
+
+  #[rstest]
   #[case("2 3 pow", 8.0)]
   #[case("3 2 pow", 9.0)]
   fn test_pow(#[case] expr: &str, #[case] expected: f32) {

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -62,6 +62,7 @@ const fn is_binop_simd_eligible(op: BinOp) -> bool {
       | BinOp::Sub
       | BinOp::Mul
       | BinOp::Div
+      | BinOp::Rem
       | BinOp::Gt
       | BinOp::Lt
       | BinOp::Eq

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -560,6 +560,13 @@ fn codegen_float_binop_simd(
     BinOp::Sub => fx.bcx.ins().fsub(lhs, rhs),
     BinOp::Mul => fx.bcx.ins().fmul(lhs, rhs),
     BinOp::Div => fx.bcx.ins().fdiv(lhs, rhs),
+    BinOp::Rem => {
+      // x - trunc(x / y) * y
+      let quot = fx.bcx.ins().fdiv(lhs, rhs);
+      let trunc_quot = fx.bcx.ins().trunc(quot);
+      let prod = fx.bcx.ins().fmul(trunc_quot, rhs);
+      fx.bcx.ins().fsub(lhs, prod)
+    }
     BinOp::Gt | BinOp::Gte | BinOp::Lt | BinOp::Lte | BinOp::Eq => {
       let float_cc = match op {
         BinOp::Gt => FloatCC::GreaterThan,
@@ -600,7 +607,7 @@ fn codegen_float_binop_simd(
       fx.bcx.ins().fcvt_from_sint(VEC_TYPE, res_i)
     }
     BinOp::Pow => unreachable!("pow is handled by pow_simd"),
-    BinOp::Rem | BinOp::Atan2 => {
+    BinOp::Atan2 => {
       unreachable!("op {op:?} should have been rejected by SIMD eligibility check")
     }
   }


### PR DESCRIPTION
Expand it inline as `x - trunc(x / y) * y`.