### PR TITLE
codegen: support integer pixel formats in SIMD path

### DIFF
--- a/crates/cranexpr-cli/src/main.rs
+++ b/crates/cranexpr-cli/src/main.rs
@@ -12,10 +12,36 @@ use cranexpr_transforms::{PropVisitor, Visitor};
 struct Args {
   /// The expression to compile.
   expr: String,
+
+  /// Source component type.
+  #[arg(long, default_value = "f32")]
+  src_type: String,
+
+  /// Destination component type.
+  #[arg(long, default_value = "f32")]
+  dst_type: String,
+}
+
+fn parse_component_type(s: &str) -> Option<ComponentType> {
+  match s {
+    "f32" => Some(ComponentType::F32),
+    "u8" => Some(ComponentType::U8),
+    "u16" => Some(ComponentType::U16),
+    _ => None,
+  }
 }
 
 fn main() -> ExitCode {
   let args = Args::parse();
+
+  let Some(src_type) = parse_component_type(&args.src_type) else {
+    eprintln!("unknown src component type: {}", args.src_type);
+    return ExitCode::FAILURE;
+  };
+  let Some(dst_type) = parse_component_type(&args.dst_type) else {
+    eprintln!("unknown dst component type: {}", args.dst_type);
+    return ExitCode::FAILURE;
+  };
 
   let ast = match cranexpr_parser::parse_expr(&args.expr) {
     Ok(ast) => ast,
@@ -33,8 +59,8 @@ fn main() -> ExitCode {
 
   match compile_clif(
     &ast,
-    ComponentType::F32,
-    &[ComponentType::F32],
+    dst_type,
+    &[src_type],
     Some(BoundaryMode::Clamp),
     &required_props,
   ) {

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -20,7 +20,9 @@ use crate::errors::{CodegenError, CodegenResult};
 use crate::pointer::Pointer;
 use crate::simd_plan::try_simd_plan;
 use crate::translate::{codegen_pixel_offset, translate_expr};
-use crate::translate_simd::{simd_lane_offsets_f32x4, translate_expr_simd};
+use crate::translate_simd::{
+  load_pixel_vec_f32x4, simd_lane_offsets_f32x4, store_pixel_vec_f32x4, translate_expr_simd,
+};
 
 pub(crate) const SRC_MEMFLAGS: MemFlags = MemFlags::trusted().with_readonly().with_can_move();
 const FRAME_PROP_MEMFLAGS: MemFlags = MemFlags::trusted().with_readonly().with_can_move();
@@ -324,20 +326,16 @@ fn build_entry_fn(
         Ok(())
       };
 
-    let f32_bytes = ComponentType::F32.bytes() as i64;
     let lane_offsets_val = simd_plan.as_ref().map(|_| simd_lane_offsets_f32x4(&mut fx));
+    let src_types_owned = src_types.to_vec();
     let simd_pixel_body =
       |fx: &mut FunctionCx<'_, '_>, y_coord: Value, x_coord: Value| -> CodegenResult<()> {
         codegen_variable(fx, "X", x_coord);
 
-        for var_idx in 0..src_types.len() {
+        for (var_idx, src_type) in src_types_owned.iter().enumerate() {
           let (src_ptr, pixel_offset) =
-            codegen_pixel_offset(fx, var_idx, x_coord, y_coord, ComponentType::F32);
-          let val = src_ptr.offset_value(fx, pixel_offset).load(
-            fx,
-            types::F32X4,
-            SRC_MEMFLAGS.with_aligned(),
-          );
+            codegen_pixel_offset(fx, var_idx, x_coord, y_coord, *src_type);
+          let val = load_pixel_vec_f32x4(fx, src_ptr, pixel_offset, *src_type, true);
 
           let var = fx.bcx.declare_var(types::F32X4);
           fx.bcx.def_var(var, val);
@@ -362,14 +360,9 @@ fn build_entry_fn(
         };
 
         let dest_row_offset = fx.bcx.ins().imul(y_coord, dst_stride);
-        let dest_col_offset = fx.bcx.ins().imul_imm(x_coord, f32_bytes);
+        let dest_col_offset = fx.bcx.ins().imul_imm(x_coord, dst_type.bytes() as i64);
         let dest_offset = fx.bcx.ins().iadd(dest_row_offset, dest_col_offset);
-        // VapourSynth guarantees row strides are aligned to at least 32 bytes.
-        dest_ptr.offset_value(fx, dest_offset).store(
-          fx,
-          expr_val,
-          MemFlags::trusted().with_aligned(),
-        );
+        store_pixel_vec_f32x4(fx, dest_ptr, dest_offset, expr_val, dst_type);
 
         fx.variables
           .retain(|k, _| !k.starts_with("simd_") && !k.starts_with("src"));
@@ -1415,5 +1408,195 @@ mod tests {
     let src: &[&[f32]] = &[&[10.0, 20.0, 30.0, 40.0]];
     let out = run_expr_padded("-1 0 x[]", src, Some(BoundaryMode::Mirror));
     assert_eq!(out, vec![vec![10.0, 10.0, 10.0, 10.0]]);
+  }
+
+  fn run_expr_u8_padded(expr: &str, src_rows: &[&[u8]]) -> Vec<Vec<u8>> {
+    let height = src_rows.len();
+    let width = src_rows[0].len();
+    assert!(src_rows.iter().all(|r| r.len() == width));
+
+    let row_padded: usize = std::cmp::max(32, width.next_multiple_of(32));
+
+    let mut src_flat: Vec<u8> = vec![0; row_padded * height];
+    for (y, row) in src_rows.iter().enumerate() {
+      src_flat[y * row_padded..y * row_padded + width].copy_from_slice(row);
+    }
+    let mut dst_flat: Vec<u8> = vec![0; row_padded * height];
+
+    let ast = cranexpr_parser::parse_expr(expr).unwrap();
+    let compiled = compile_jit(&ast, ComponentType::U8, &[ComponentType::U8], None, &[])
+      .expect("should compile expr");
+
+    let stride = row_padded as i64;
+    let src_ptrs = [src_flat.as_ptr()];
+    let src_strides = [stride];
+
+    unsafe {
+      compiled.invoke(
+        &mut dst_flat[..],
+        stride,
+        &src_ptrs,
+        &src_strides,
+        width as i32,
+        height as i32,
+        0,
+        &[],
+      );
+    }
+
+    (0..height)
+      .map(|y| dst_flat[y * row_padded..y * row_padded + width].to_vec())
+      .collect()
+  }
+
+  fn run_expr_u16_padded(expr: &str, src_rows: &[&[u16]]) -> Vec<Vec<u16>> {
+    let height = src_rows.len();
+    let width = src_rows[0].len();
+    assert!(src_rows.iter().all(|r| r.len() == width));
+
+    let row_padded: usize = std::cmp::max(16, width.next_multiple_of(16));
+
+    let mut src_flat: Vec<u16> = vec![0; row_padded * height];
+    for (y, row) in src_rows.iter().enumerate() {
+      src_flat[y * row_padded..y * row_padded + width].copy_from_slice(row);
+    }
+    let mut dst_flat: Vec<u16> = vec![0; row_padded * height];
+
+    let ast = cranexpr_parser::parse_expr(expr).unwrap();
+    let compiled = compile_jit(&ast, ComponentType::U16, &[ComponentType::U16], None, &[])
+      .expect("should compile expr");
+
+    let stride = (row_padded * std::mem::size_of::<u16>()) as i64;
+    let src_ptrs = [src_flat.as_ptr().cast::<u8>()];
+    let src_strides = [stride];
+
+    unsafe {
+      compiled.invoke(
+        &mut dst_flat[..],
+        stride,
+        &src_ptrs,
+        &src_strides,
+        width as i32,
+        height as i32,
+        0,
+        &[],
+      );
+    }
+
+    (0..height)
+      .map(|y| dst_flat[y * row_padded..y * row_padded + width].to_vec())
+      .collect()
+  }
+
+  #[rstest]
+  fn test_simd_u8_identity() {
+    let src: &[&[u8]] = &[&[0, 1, 2, 3, 10, 20, 30, 40]];
+    let out = run_expr_u8_padded("x", src);
+    assert_eq!(out, vec![vec![0, 1, 2, 3, 10, 20, 30, 40]]);
+  }
+
+  #[rstest]
+  fn test_simd_u8_arithmetic() {
+    let src: &[&[u8]] = &[&[0, 1, 2, 3, 4, 5, 6, 7]];
+    let out = run_expr_u8_padded("x 2 *", src);
+    assert_eq!(out, vec![vec![0, 2, 4, 6, 8, 10, 12, 14]]);
+  }
+
+  #[rstest]
+  fn test_simd_u8_saturating_store() {
+    let src: &[&[u8]] = &[&[0, 50, 100, 150, 200, 250, 255, 255]];
+    let out = run_expr_u8_padded("x 2 *", src);
+    assert_eq!(out, vec![vec![0, 100, 200, 255, 255, 255, 255, 255]]);
+  }
+
+  #[rstest]
+  fn test_simd_u8_negative_saturation() {
+    let src: &[&[u8]] = &[&[0, 5, 9, 10, 15, 20, 100, 200]];
+    let out = run_expr_u8_padded("x 10 -", src);
+    assert_eq!(out, vec![vec![0, 0, 0, 0, 5, 10, 90, 190]]);
+  }
+
+  #[rstest]
+  fn test_simd_u8_rel_access_right() {
+    let src: &[&[u8]] = &[&[10, 20, 30, 40, 50, 60, 70, 80]];
+    let out = run_expr_u8_padded("x[1,0]", src);
+    assert_eq!(out, vec![vec![20, 30, 40, 50, 60, 70, 80, 80]]);
+  }
+
+  #[rstest]
+  fn test_simd_u8_non_multiple_width_tail() {
+    let src: &[&[u8]] = &[&[1, 2, 3, 4, 5, 6, 7]];
+    let out = run_expr_u8_padded("x 3 +", src);
+    assert_eq!(out, vec![vec![4, 5, 6, 7, 8, 9, 10]]);
+  }
+
+  #[rstest]
+  fn test_simd_u16_identity() {
+    let src: &[&[u16]] = &[&[0, 1, 2, 3, 1000, 2000, 30000, 60000]];
+    let out = run_expr_u16_padded("x", src);
+    assert_eq!(out, vec![vec![0, 1, 2, 3, 1000, 2000, 30000, 60000]]);
+  }
+
+  #[rstest]
+  fn test_simd_u16_arithmetic_with_saturation() {
+    let src: &[&[u16]] = &[&[0, 100, 1000, 10000, 20000, 30000, 40000, 60000]];
+    let out = run_expr_u16_padded("x 3 *", src);
+    assert_eq!(
+      out,
+      vec![vec![0, 300, 3000, 30000, 60000, 65535, 65535, 65535]]
+    );
+  }
+
+  #[rstest]
+  fn test_simd_u16_rel_access_left() {
+    let src: &[&[u16]] = &[&[10, 20, 30, 40, 50, 60, 70, 80]];
+    let out = run_expr_u16_padded("x[-1,0]", src);
+    assert_eq!(out, vec![vec![10, 10, 20, 30, 40, 50, 60, 70]]);
+  }
+
+  #[rstest]
+  fn test_simd_mixed_sources_u8_u16() {
+    let x_rows: &[u8] = &[10, 20, 30, 40, 50, 60, 70, 80];
+    let y_rows: &[u16] = &[100, 200, 300, 400, 500, 600, 700, 800];
+    let width = 8usize;
+    let height = 1usize;
+    let row_padded_u8 = 32usize;
+    let row_padded_u16 = 16usize;
+
+    let mut x_flat = vec![0u8; row_padded_u8 * height];
+    x_flat[..width].copy_from_slice(x_rows);
+    let mut y_flat = vec![0u16; row_padded_u16 * height];
+    y_flat[..width].copy_from_slice(y_rows);
+    let mut dst_flat = vec![0u16; row_padded_u16 * height];
+
+    let ast = cranexpr_parser::parse_expr("x y +").unwrap();
+    let compiled = compile_jit(
+      &ast,
+      ComponentType::U16,
+      &[ComponentType::U8, ComponentType::U16],
+      None,
+      &[],
+    )
+    .expect("should compile expr");
+
+    let src_ptrs = [x_flat.as_ptr(), y_flat.as_ptr().cast::<u8>()];
+    let src_strides = [row_padded_u8 as i64, (row_padded_u16 * 2) as i64];
+    let dst_stride = (row_padded_u16 * 2) as i64;
+
+    unsafe {
+      compiled.invoke(
+        &mut dst_flat[..],
+        dst_stride,
+        &src_ptrs,
+        &src_strides,
+        width as i32,
+        height as i32,
+        0,
+        &[],
+      );
+    }
+
+    let out: Vec<u16> = dst_flat[..width].to_vec();
+    assert_eq!(out, vec![110, 220, 330, 440, 550, 660, 770, 880]);
   }
 }

--- a/crates/cranexpr-codegen/src/simd_plan.rs
+++ b/crates/cranexpr-codegen/src/simd_plan.rs
@@ -11,15 +11,9 @@ pub(crate) struct SimdPlan {
 
 pub(crate) fn try_simd_plan(
   ast: &[Expr],
-  dst_type: ComponentType,
-  src_types: &[ComponentType],
+  _dst_type: ComponentType,
+  _src_types: &[ComponentType],
 ) -> Option<SimdPlan> {
-  if dst_type != ComponentType::F32 {
-    return None;
-  }
-  if src_types.iter().any(|t| *t != ComponentType::F32) {
-    return None;
-  }
   if ast.is_empty() {
     return None;
   }

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -7,10 +7,90 @@ use cranexpr_ast::{BinOp, BoundaryMode, Expr, TernaryOp, UnOp};
 use crate::compiler::{FunctionCx, SRC_MEMFLAGS};
 use crate::component_type::ComponentType;
 use crate::errors::CodegenError;
+use crate::pointer::Pointer;
 use crate::simd_plan::SIMD_LANES;
 use crate::translate::{codegen_boundary_mode, codegen_pixel_offset, resolve_clip_name};
 
 const VEC_TYPE: types::Type = types::F32X4;
+
+/// Loads 4 adjacent pixels of arbitrary component type at `src_ptr + offset`,
+/// promoting them to an `F32X4` vector.
+pub(crate) fn load_pixel_vec_f32x4(
+  fx: &mut FunctionCx<'_, '_>,
+  src_ptr: Pointer,
+  offset: Value,
+  src_type: ComponentType,
+  aligned: bool,
+) -> Value {
+  let ptr = src_ptr.offset_value(fx, offset);
+  match src_type {
+    ComponentType::F32 => {
+      let flags = if aligned {
+        SRC_MEMFLAGS.with_aligned()
+      } else {
+        SRC_MEMFLAGS
+      };
+      ptr.load(fx, VEC_TYPE, flags)
+    }
+    ComponentType::U16 => {
+      let addr = ptr.get_addr(fx);
+      let i32x4 = fx.bcx.ins().uload16x4(SRC_MEMFLAGS, addr, 0);
+      fx.bcx.ins().fcvt_from_uint(VEC_TYPE, i32x4)
+    }
+    ComponentType::U8 => {
+      let addr = ptr.get_addr(fx);
+      let i16x8 = fx.bcx.ins().uload8x8(SRC_MEMFLAGS, addr, 0);
+      let i32x4 = fx.bcx.ins().uwiden_low(i16x8);
+      fx.bcx.ins().fcvt_from_uint(VEC_TYPE, i32x4)
+    }
+  }
+}
+
+/// Clamps, rounds, converts, and narrows an `F32X4` output vector to the
+/// destination pixel format, then stores 4 pixels at `dest + offset`.
+pub(crate) fn store_pixel_vec_f32x4(
+  fx: &mut FunctionCx<'_, '_>,
+  dest_ptr: Pointer,
+  offset: Value,
+  value: Value,
+  dst_type: ComponentType,
+) {
+  let ptr = dest_ptr.offset_value(fx, offset);
+  match dst_type {
+    ComponentType::F32 => {
+      // VapourSynth guarantees row strides are aligned to at least 32 bytes.
+      ptr.store(fx, value, MemFlags::trusted().with_aligned());
+    }
+    ComponentType::U8 | ComponentType::U16 => {
+      let zero = splat_f32(fx, 0.0);
+      let peak = splat_f32(fx, dst_type.peak_value());
+      let clamped = fx.bcx.ins().fmin(value, peak);
+      let clamped = fx.bcx.ins().fmax(clamped, zero);
+      let rounded = fx.bcx.ins().nearest(clamped);
+      let i32x4 = fx.bcx.ins().fcvt_to_uint_sat(types::I32X4, rounded);
+      let byte_flags = MemFlags::new().with_endianness(Endianness::Little);
+      match dst_type {
+        ComponentType::U16 => {
+          // Narrow I32X4 -> I16X8 with unsigned saturation.
+          let narrowed = fx.bcx.ins().unarrow(i32x4, i32x4);
+          let as_i64x2 = fx.bcx.ins().bitcast(types::I64X2, byte_flags, narrowed);
+          let low = fx.bcx.ins().extractlane(as_i64x2, 0);
+          ptr.store(fx, low, MemFlags::trusted());
+        }
+        ComponentType::U8 => {
+          // Narrow I32X4 -> I16X8 (unsigned saturating),
+          // then narrow I16X8 -> I8X16 (unsigned saturating).
+          let n16 = fx.bcx.ins().unarrow(i32x4, i32x4);
+          let n8 = fx.bcx.ins().unarrow(n16, n16);
+          let as_i32x4 = fx.bcx.ins().bitcast(types::I32X4, byte_flags, n8);
+          let low = fx.bcx.ins().extractlane(as_i32x4, 0);
+          ptr.store(fx, low, MemFlags::trusted());
+        }
+        ComponentType::F32 => unreachable!(),
+      }
+    }
+  }
+}
 
 pub(crate) fn translate_expr_simd(
   fx: &mut FunctionCx<'_, '_>,
@@ -729,6 +809,8 @@ fn translate_rel_access_simd(
   let x_base = fx.bcx.use_var(*x_var);
   let y_base = fx.bcx.use_var(*y_var);
 
+  let src_type = fx.src_types[clip_idx];
+
   let target_y = if rel_y == 0 {
     y_base
   } else {
@@ -738,12 +820,13 @@ fn translate_rel_access_simd(
   };
 
   if rel_x == 0 {
-    let (src_ptr, pixel_offset) =
-      codegen_pixel_offset(fx, clip_idx, x_base, target_y, ComponentType::F32);
-    return Ok(src_ptr.offset_value(fx, pixel_offset).load(
+    let (src_ptr, pixel_offset) = codegen_pixel_offset(fx, clip_idx, x_base, target_y, src_type);
+    return Ok(load_pixel_vec_f32x4(
       fx,
-      VEC_TYPE,
-      SRC_MEMFLAGS.with_aligned(),
+      src_ptr,
+      pixel_offset,
+      src_type,
+      true,
     ));
   }
 
@@ -764,6 +847,7 @@ fn translate_rel_access_clamp_x(
   target_y: Value,
   x_base: Value,
 ) -> Value {
+  let src_type = fx.src_types[clip_idx];
   let width = fx.width;
   let one = fx.bcx.ins().iconst(types::I64, 1);
   let zero = fx.bcx.ins().iconst(types::I64, 0);
@@ -780,11 +864,8 @@ fn translate_rel_access_clamp_x(
   let too_small = fx.bcx.ins().icmp(IntCC::SignedLessThan, clamped_hi, zero);
   let clamped_x = fx.bcx.ins().select(too_small, zero, clamped_hi);
 
-  let (src_ptr, pixel_offset) =
-    codegen_pixel_offset(fx, clip_idx, clamped_x, target_y, ComponentType::F32);
-  let raw = src_ptr
-    .offset_value(fx, pixel_offset)
-    .load(fx, VEC_TYPE, SRC_MEMFLAGS);
+  let (src_ptr, pixel_offset) = codegen_pixel_offset(fx, clip_idx, clamped_x, target_y, src_type);
+  let raw = load_pixel_vec_f32x4(fx, src_ptr, pixel_offset, src_type, false);
 
   if rel_x < 0 {
     apply_left_swizzle_fixup(fx, raw, x_base, rel_x)
@@ -939,6 +1020,7 @@ fn translate_rel_access_mirror_x(
   target_y: Value,
   x_base: Value,
 ) -> Value {
+  let src_type = fx.src_types[clip_idx];
   let lanes = SIMD_LANES;
   let rel_x_val = fx.bcx.ins().iconst(types::I64, i64::from(rel_x));
 
@@ -950,10 +1032,8 @@ fn translate_rel_access_mirror_x(
     let x_shifted = fx.bcx.ins().iadd(x_unshifted, rel_x_val);
     let x_mirrored = codegen_boundary_mode(fx, x_shifted, fx.width, BoundaryMode::Mirror);
     let (src_ptr, pixel_offset) =
-      codegen_pixel_offset(fx, clip_idx, x_mirrored, target_y, ComponentType::F32);
-    let scalar = src_ptr
-      .offset_value(fx, pixel_offset)
-      .load(fx, types::F32, SRC_MEMFLAGS);
+      codegen_pixel_offset(fx, clip_idx, x_mirrored, target_y, src_type);
+    let scalar = load_scalar_as_f32(fx, src_ptr, pixel_offset, src_type);
     vec = fx.bcx.ins().insertlane(vec, scalar, lane as u8);
   }
   vec
@@ -966,6 +1046,7 @@ fn translate_abs_access_simd(
   y_vec: Value,
   boundary_mode: BoundaryMode,
 ) -> Value {
+  let src_type = fx.src_types[clip_idx];
   let x_rounded = fx.bcx.ins().nearest(x_vec);
   let y_rounded = fx.bcx.ins().nearest(y_vec);
   let x_i32x4 = fx.bcx.ins().fcvt_to_sint_sat(types::I32X4, x_rounded);
@@ -981,11 +1062,26 @@ fn translate_abs_access_simd(
     let clamped_x = codegen_boundary_mode(fx, x_lane, fx.width, boundary_mode);
     let clamped_y = codegen_boundary_mode(fx, y_lane, fx.height, boundary_mode);
     let (src_ptr, pixel_offset) =
-      codegen_pixel_offset(fx, clip_idx, clamped_x, clamped_y, ComponentType::F32);
-    let scalar = src_ptr
-      .offset_value(fx, pixel_offset)
-      .load(fx, types::F32, SRC_MEMFLAGS);
+      codegen_pixel_offset(fx, clip_idx, clamped_x, clamped_y, src_type);
+    let scalar = load_scalar_as_f32(fx, src_ptr, pixel_offset, src_type);
     vec = fx.bcx.ins().insertlane(vec, scalar, lane as u8);
   }
   vec
+}
+
+/// Loads a single pixel of arbitrary component type at `src_ptr + offset` and
+/// promotes it to an `F32` scalar.
+fn load_scalar_as_f32(
+  fx: &mut FunctionCx<'_, '_>,
+  src_ptr: Pointer,
+  offset: Value,
+  src_type: ComponentType,
+) -> Value {
+  let val = src_ptr
+    .offset_value(fx, offset)
+    .load(fx, src_type.into(), SRC_MEMFLAGS);
+  match src_type {
+    ComponentType::U8 | ComponentType::U16 => fx.bcx.ins().fcvt_from_uint(types::F32, val),
+    ComponentType::F32 => val,
+  }
 }


### PR DESCRIPTION
Add load/store helpers that promote 4 adjacent integer pixels to `F32X4` on load so that the existing vector pipeline can handle mixed integer and float formats.

Also add `--src-type`` / `--dst-type` flags to the CLI to make it easy to inspect the generated IR for integer clips.