### PR TITLE
codegen: use Arc for shared AST nodes and memoize

### DIFF
--- a/crates/cranexpr-ast/Cargo.toml
+++ b/crates/cranexpr-ast/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 num-derive = "=0.4.2"
 num-traits = "=0.2.19"
-serde = { version = "=1.0.228", features = ["derive"] }
+serde = { version = "=1.0.228", features = ["derive", "rc"] }
 strum = "=0.28.0"
 strum_macros = "=0.28.0"
 

--- a/crates/cranexpr-ast/src/lib.rs
+++ b/crates/cranexpr-ast/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use num_derive::FromPrimitive;
 use serde::Serialize;
 use strum_macros::{Display, EnumString};
@@ -141,13 +143,13 @@ pub enum TernaryOp {
 #[derive(Clone, Debug, Serialize)]
 pub enum Expr {
   /// A binary operation (e.g., `a b +`, `a b *`).
-  Binary(BinOp, Box<Self>, Box<Self>),
+  Binary(BinOp, Arc<Self>, Arc<Self>),
 
   /// A unary operation (e.g., `x sin`, `x exp`).
-  Unary(UnOp, Box<Self>),
+  Unary(UnOp, Arc<Self>),
 
   /// A ternary operation (e.g., `x min_val max_val clip`).
-  Ternary(TernaryOp, Box<Self>, Box<Self>, Box<Self>),
+  Ternary(TernaryOp, Arc<Self>, Arc<Self>, Arc<Self>),
 
   /// A literal (e.g., `1e-06`).
   Lit(f32),
@@ -156,13 +158,13 @@ pub enum Expr {
   Ident(String),
 
   /// If/else, ternary.
-  IfElse(Box<Self>, Box<Self>, Box<Self>),
+  IfElse(Arc<Self>, Arc<Self>, Arc<Self>),
 
   /// Access of a frame property (e.g. `x.PlaneStatsAverage`).
   Prop(String, String),
 
   /// Store a value into a variable.
-  Store(String, Box<Self>),
+  Store(String, Arc<Self>),
 
   /// Load a value from a variable.
   Load(String),
@@ -188,10 +190,10 @@ pub enum Expr {
     clip: String,
 
     /// Absolute X coordinate.
-    x: Box<Self>,
+    x: Arc<Self>,
 
     /// Absolute Y coordinate.
-    y: Box<Self>,
+    y: Arc<Self>,
 
     /// Optional boundary mode override.
     ///

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::f32::consts::PI;
+use std::ptr::NonNull;
 use std::sync::Arc;
 
 use cranelift::codegen::ir::immediates::Offset32;
@@ -51,6 +52,9 @@ pub(crate) struct FunctionCx<'m, 'clif> {
   pub(crate) height: Value,
 
   pub(crate) comments: CommentWriter,
+
+  /// Memoization cache.
+  pub(crate) cache: HashMap<NonNull<Expr>, Value>,
 }
 
 struct BuiltEntryFn {
@@ -229,6 +233,7 @@ fn build_entry_fn(
       width,
       height,
       comments: CommentWriter::new(),
+      cache: HashMap::new(),
     };
 
     // Constants.
@@ -294,6 +299,7 @@ fn build_entry_fn(
         fx.variables
           .retain(|k, _| !k.starts_with("simd_") && !k.starts_with("src"));
         fx.user_variables.clear();
+        fx.cache.clear();
 
         Ok(())
       };

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -1,4 +1,5 @@
 use std::f32::consts::{FRAC_PI_2, LN_2, LOG2_E, PI};
+use std::ptr::NonNull;
 
 use cranelift::codegen::ir::{ConstantData, Endianness};
 use cranelift::prelude::*;
@@ -95,6 +96,19 @@ pub(crate) fn store_pixel_vec_f32x4(
 }
 
 pub(crate) fn translate_expr_simd(
+  fx: &mut FunctionCx<'_, '_>,
+  expr: &Expr,
+) -> Result<Value, CodegenError> {
+  let cache_key = NonNull::from(expr);
+  if let Some(&cached) = fx.cache.get(&cache_key) {
+    return Ok(cached);
+  }
+  let result = translate_expr_simd_inner(fx, expr)?;
+  fx.cache.insert(cache_key, result);
+  Ok(result)
+}
+
+fn translate_expr_simd_inner(
   fx: &mut FunctionCx<'_, '_>,
   expr: &Expr,
 ) -> Result<Value, CodegenError> {

--- a/crates/cranexpr-parser/src/lib.rs
+++ b/crates/cranexpr-parser/src/lib.rs
@@ -3,19 +3,21 @@ mod sorting_network;
 
 pub use errors::ParseError;
 
+use std::sync::Arc;
+
 use cranexpr_ast::{BinOp, BoundaryMode, Expr, TernaryOp, UnOp};
 use cranexpr_lexer::{TokenKind, tokenize_with_text};
 
 fn add_unary_op(stack: &mut Vec<Expr>, op: UnOp) -> Result<(), ParseError> {
   let x = stack.pop().ok_or(ParseError::StackUnderflow)?;
-  stack.push(Expr::Unary(op, Box::new(x)));
+  stack.push(Expr::Unary(op, Arc::new(x)));
   Ok(())
 }
 
 fn add_binary_op(stack: &mut Vec<Expr>, op: BinOp) -> Result<(), ParseError> {
   let right = stack.pop().ok_or(ParseError::StackUnderflow)?;
   let left = stack.pop().ok_or(ParseError::StackUnderflow)?;
-  stack.push(Expr::Binary(op, Box::new(left), Box::new(right)));
+  stack.push(Expr::Binary(op, Arc::new(left), Arc::new(right)));
   Ok(())
 }
 
@@ -23,7 +25,7 @@ fn add_ternary_op(stack: &mut Vec<Expr>, op: TernaryOp) -> Result<(), ParseError
   let c = stack.pop().ok_or(ParseError::StackUnderflow)?;
   let b = stack.pop().ok_or(ParseError::StackUnderflow)?;
   let a = stack.pop().ok_or(ParseError::StackUnderflow)?;
-  stack.push(Expr::Ternary(op, Box::new(a), Box::new(b), Box::new(c)));
+  stack.push(Expr::Ternary(op, Arc::new(a), Arc::new(b), Arc::new(c)));
   Ok(())
 }
 
@@ -96,8 +98,8 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
 
             stack.push(Expr::AbsAccess {
               clip: text.to_string(),
-              x: Box::new(x),
-              y: Box::new(y),
+              x: Arc::new(x),
+              y: Arc::new(y),
               boundary_mode,
             });
           } else {
@@ -256,8 +258,8 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
             let sj = start + j;
             let a = stack[si].clone();
             let b = stack[sj].clone();
-            stack[si] = Expr::Binary(BinOp::Max, Box::new(a.clone()), Box::new(b.clone()));
-            stack[sj] = Expr::Binary(BinOp::Min, Box::new(a), Box::new(b));
+            stack[si] = Expr::Binary(BinOp::Max, Arc::new(a.clone()), Arc::new(b.clone()));
+            stack[sj] = Expr::Binary(BinOp::Min, Arc::new(a), Arc::new(b));
           }
         }
         // `var!`: Pops the top value from the stack and stores it in a variable
@@ -265,7 +267,7 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
         else if tokens.peek().is_some_and(|(k, _)| *k == TokenKind::Bang) {
           tokens.next(); // Consume `!`.
           let value = stack.pop().ok_or(ParseError::StackUnderflow)?;
-          side_effects.push(Expr::Store(text.to_string(), Box::new(value)));
+          side_effects.push(Expr::Store(text.to_string(), Arc::new(value)));
         }
         // `var@`: Pushes the value of the variable `var` onto the stack.
         else if tokens.peek().is_some_and(|(k, _)| *k == TokenKind::At) {
@@ -344,7 +346,7 @@ pub fn parse_expr(expr: &str) -> Result<Vec<Expr>, ParseError> {
         let yes = stack.pop().ok_or(ParseError::StackUnderflow)?;
         let cond = stack.pop().ok_or(ParseError::StackUnderflow)?;
 
-        stack.push(Expr::IfElse(Box::new(cond), Box::new(yes), Box::new(no)));
+        stack.push(Expr::IfElse(Arc::new(cond), Arc::new(yes), Arc::new(no)));
       }
       _ => return Err(ParseError::UnrecognizedToken(text.to_string())),
     }


### PR DESCRIPTION
At the moment we have the parser cloning stack entries on every `dup` operation. With `Box<Self>`, each clone deep-copies the entire subtree, causing exponential memory growth for expressions with high dup indices (e.g. the 3d-rendering benchmark).

Switching `Expr` fields from `Box<Self>` to `Arc<Self>` makes cloning an O(1) refcount bump. However, codegen still re-traverses each shared subtree every time it encounters a reference, which is exponential in time. Adding a memoization cache keyed ensures each unique subtree is only compiled once per iteration.