### PR TITLE
transforms: cancel inverse exp/log pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "cranelift-native",
  "cranexpr-ast",
  "cranexpr-parser",
+ "cranexpr-transforms",
  "miette",
  "nanoid",
  "ndarray",

--- a/crates/cranexpr-codegen/Cargo.toml
+++ b/crates/cranexpr-codegen/Cargo.toml
@@ -18,6 +18,7 @@ cranelift-native = "=0.132.0"
 
 cranexpr-ast = { workspace = true }
 cranexpr-parser = { workspace = true }
+cranexpr-transforms = { workspace = true }
 
 [dev-dependencies]
 aligned-vec = "=0.6.4"

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -12,6 +12,7 @@ use cranelift::{codegen::Context, prelude::FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{FuncId, Linkage, Module, ModuleError};
 use cranexpr_ast::{BoundaryMode, Expr};
+use cranexpr_transforms::simplify;
 use nanoid::nanoid;
 
 use crate::MainFunction;
@@ -112,10 +113,11 @@ pub fn compile_jit(
   boundary_mode: Option<BoundaryMode>,
   required_frame_props: &[(usize, String)],
 ) -> Result<MainFunction, CodegenError> {
+  let ast: Vec<Expr> = ast.iter().map(simplify).collect();
   let mut jit_module = create_jit_module();
   let mut main_func = build_entry_fn(
     &mut jit_module,
-    ast,
+    &ast,
     dst_type,
     src_types,
     boundary_mode,
@@ -149,10 +151,11 @@ pub fn compile_clif(
   boundary_mode: Option<BoundaryMode>,
   required_frame_props: &[(usize, String)],
 ) -> Result<String, CodegenError> {
+  let ast: Vec<Expr> = ast.iter().map(simplify).collect();
   let mut jit_module = create_jit_module();
   let mut built = build_entry_fn(
     &mut jit_module,
-    ast,
+    &ast,
     dst_type,
     src_types,
     boundary_mode,
@@ -187,8 +190,9 @@ pub fn compile_jit_select(
   num_prop_clips: usize,
   required_frame_props: &[(usize, String)],
 ) -> Result<SelectFunction, CodegenError> {
+  let ast: Vec<Expr> = ast.iter().map(simplify).collect();
   let mut jit_module = create_jit_module();
-  let mut built = build_select_fn(&mut jit_module, ast, num_prop_clips, required_frame_props)?;
+  let mut built = build_select_fn(&mut jit_module, &ast, num_prop_clips, required_frame_props)?;
 
   if let Err(err) = jit_module.define_function(built.func_id, &mut built.ctx) {
     let err_msg = match err {

--- a/crates/cranexpr-transforms/src/lib.rs
+++ b/crates/cranexpr-transforms/src/lib.rs
@@ -3,9 +3,11 @@
 mod errors;
 mod pixel_access_visitor;
 mod prop_visitor;
+mod simplify;
 mod visit;
 
 pub use errors::TransformError;
 pub use pixel_access_visitor::PixelAccessVisitor;
 pub use prop_visitor::PropVisitor;
-pub use visit::{Visitor, walk_expr};
+pub use simplify::simplify;
+pub use visit::{MutVisitor, Visitor, walk_expr, walk_expr_mut};

--- a/crates/cranexpr-transforms/src/simplify.rs
+++ b/crates/cranexpr-transforms/src/simplify.rs
@@ -1,0 +1,106 @@
+//! Algebraic simplification of expression ASTs.
+
+use cranexpr_ast::{Expr, UnOp};
+
+use crate::visit::{MutVisitor, walk_expr_mut};
+
+const fn are_inverses(a: UnOp, b: UnOp) -> bool {
+  matches!((a, b), (UnOp::Exp, UnOp::Log) | (UnOp::Log, UnOp::Exp))
+}
+
+struct Simplify;
+
+impl MutVisitor for Simplify {
+  fn fold_expr(&mut self, expr: &Expr) -> Expr {
+    let expr = walk_expr_mut(self, expr);
+    if let Expr::Unary(outer_op, inner) = &expr
+      && let Expr::Unary(inner_op, x) = inner.as_ref()
+      && are_inverses(*outer_op, *inner_op)
+    {
+      return x.as_ref().clone();
+    }
+    expr
+  }
+}
+
+#[must_use]
+pub fn simplify(expr: &Expr) -> Expr {
+  Simplify.fold_expr(expr)
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+
+  use super::*;
+  use cranexpr_ast::BinOp;
+
+  fn ident(name: &str) -> Expr {
+    Expr::Ident(name.to_string())
+  }
+
+  fn unary(op: UnOp, inner: Expr) -> Expr {
+    Expr::Unary(op, Arc::new(inner))
+  }
+
+  #[test]
+  fn exp_then_log_cancels() {
+    let expr = unary(UnOp::Log, unary(UnOp::Exp, ident("x")));
+    let result = simplify(&expr);
+    assert!(matches!(result, Expr::Ident(s) if s == "x"));
+  }
+
+  #[test]
+  fn log_then_exp_cancels() {
+    let expr = unary(UnOp::Exp, unary(UnOp::Log, ident("x")));
+    let result = simplify(&expr);
+    assert!(matches!(result, Expr::Ident(s) if s == "x"));
+  }
+
+  #[test]
+  fn nested_double_inverse_cancels() {
+    // exp log exp log -> identity
+    let expr = unary(
+      UnOp::Log,
+      unary(UnOp::Exp, unary(UnOp::Log, unary(UnOp::Exp, ident("x")))),
+    );
+    let result = simplify(&expr);
+    assert!(matches!(result, Expr::Ident(s) if s == "x"));
+  }
+
+  #[test]
+  fn non_inverse_pair_unchanged() {
+    let expr = unary(UnOp::Log, unary(UnOp::Sine, ident("x")));
+    let result = simplify(&expr);
+    assert!(matches!(result, Expr::Unary(UnOp::Log, _)));
+  }
+
+  #[test]
+  fn cancellation_inside_binary() {
+    let expr = Expr::Binary(
+      BinOp::Add,
+      Arc::new(unary(UnOp::Log, unary(UnOp::Exp, ident("x")))),
+      Arc::new(ident("y")),
+    );
+    let result = simplify(&expr);
+    if let Expr::Binary(BinOp::Add, lhs, _) = &result {
+      assert!(matches!(lhs.as_ref(), Expr::Ident(s) if s == "x"));
+    } else {
+      panic!("expected Binary");
+    }
+  }
+
+  #[test]
+  fn preserves_surrounding_ops() {
+    // x sqrt sin exp log -> x sqrt sin
+    let expr = unary(
+      UnOp::Log,
+      unary(UnOp::Exp, unary(UnOp::Sine, unary(UnOp::Sqrt, ident("x")))),
+    );
+    let result = simplify(&expr);
+    assert!(matches!(result, Expr::Unary(UnOp::Sine, _)));
+    if let Expr::Unary(UnOp::Sine, inner) = &result {
+      assert!(matches!(inner.as_ref(), Expr::Unary(UnOp::Sqrt, _)));
+    }
+  }
+}

--- a/crates/cranexpr-transforms/src/visit.rs
+++ b/crates/cranexpr-transforms/src/visit.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+use std::sync::Arc;
 
 use cranexpr_ast::{BinOp, Expr, TernaryOp, UnOp};
 
@@ -80,3 +80,47 @@ const fn walk_unary_op<'a, V: Visitor<'a>>(_visitor: &mut V, _op: &'a UnOp) {}
 const fn walk_prop<'a, V: Visitor<'a>>(_visitor: &mut V, _name: &'a str, _prop: &'a str) {}
 const fn walk_store<'a, V: Visitor<'a>>(_visitor: &mut V, _name: &'a str) {}
 const fn walk_load<'a, V: Visitor<'a>>(_visitor: &mut V, _name: &'a str) {}
+
+/// A folding visitor that produces a new AST.
+pub trait MutVisitor: Sized {
+  fn fold_expr(&mut self, expr: &Expr) -> Expr {
+    walk_expr_mut(self, expr)
+  }
+}
+
+pub fn walk_expr_mut<V: MutVisitor>(visitor: &mut V, expr: &Expr) -> Expr {
+  match expr {
+    Expr::Unary(op, inner) => Expr::Unary(*op, Arc::new(visitor.fold_expr(inner))),
+    Expr::Binary(op, lhs, rhs) => Expr::Binary(
+      *op,
+      Arc::new(visitor.fold_expr(lhs)),
+      Arc::new(visitor.fold_expr(rhs)),
+    ),
+    Expr::Ternary(op, a, b, c) => Expr::Ternary(
+      *op,
+      Arc::new(visitor.fold_expr(a)),
+      Arc::new(visitor.fold_expr(b)),
+      Arc::new(visitor.fold_expr(c)),
+    ),
+    Expr::IfElse(cond, then_br, else_br) => Expr::IfElse(
+      Arc::new(visitor.fold_expr(cond)),
+      Arc::new(visitor.fold_expr(then_br)),
+      Arc::new(visitor.fold_expr(else_br)),
+    ),
+    Expr::Store(name, val) => Expr::Store(name.clone(), Arc::new(visitor.fold_expr(val))),
+    Expr::AbsAccess {
+      clip,
+      x,
+      y,
+      boundary_mode,
+    } => Expr::AbsAccess {
+      clip: clip.clone(),
+      x: Arc::new(visitor.fold_expr(x)),
+      y: Arc::new(visitor.fold_expr(y)),
+      boundary_mode: *boundary_mode,
+    },
+    Expr::Lit(_) | Expr::Ident(_) | Expr::Prop(..) | Expr::Load(_) | Expr::RelAccess { .. } => {
+      expr.clone()
+    }
+  }
+}


### PR DESCRIPTION
This adds an algebraic simplification pass that eliminates adjacent inverse unary pairs bottom-up before Cranelift IR generation.