### PR TITLE
codegen: use exponentiation by squaring for pow

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -987,11 +987,30 @@ mod tests {
       ("x 6 pow", 6.0),
       ("x 7 pow", 7.0),
       ("x 8 pow", 8.0),
+      ("x 9 pow", 9.0),
+      ("x 11 pow", 11.0),
+      ("x 13 pow", 13.0),
+      ("x 15 pow", 15.0),
+      ("x 17 pow", 17.0),
+      ("x 19 pow", 19.0),
     ] {
       let out = run_expr_padded(expr, src, None);
       for (i, &v) in src[0].iter().enumerate() {
         let expected = v.powf(exponent);
         assert_relative_eq!(out[0][i], expected, epsilon = 5e-5);
+      }
+    }
+  }
+
+  #[rstest]
+  fn test_pow_negative_base_large_exponent() {
+    let src: &[&[f32]] = &[&[-0.5, -1.5, -2.0, -0.25]];
+    for exp in [9, 11, 13, 15, 17, 19] {
+      let expr = format!("x {exp} pow");
+      let out = run_expr_padded(&expr, src, None);
+      for (i, &v) in src[0].iter().enumerate() {
+        let expected = v.powi(exp);
+        assert_relative_eq!(out[0][i], expected, epsilon = 5e-3);
       }
     }
   }

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -611,6 +611,19 @@ fn log_simd(fx: &mut FunctionCx<'_, '_>, x: Value) -> Value {
   vselect_f32x4(fx, is_zero, neg_inf, r)
 }
 
+pub(crate) fn fpow_by_squaring(fx: &mut FunctionCx<'_, '_>, base: Value, exp: u32) -> Value {
+  debug_assert!(exp >= 3);
+  let bits = u32::BITS - exp.leading_zeros();
+  let mut result = base;
+  for i in (0..bits - 1).rev() {
+    result = fx.bcx.ins().fmul(result, result);
+    if (exp >> i) & 1 == 1 {
+      result = fx.bcx.ins().fmul(result, base);
+    }
+  }
+  result
+}
+
 fn pow_simd(
   fx: &mut FunctionCx<'_, '_>,
   base: &Expr,
@@ -633,30 +646,8 @@ fn pow_simd(
       return Ok(fx.bcx.ins().sqrt(base_val));
     }
     let exp_u32 = *exp as u32;
-    if *exp == exp_u32 as f32 && (3..=8).contains(&exp_u32) {
-      let x2 = fx.bcx.ins().fmul(base_val, base_val);
-      return Ok(match exp_u32 {
-        3 => fx.bcx.ins().fmul(x2, base_val),
-        4 => fx.bcx.ins().fmul(x2, x2),
-        5 => {
-          let x4 = fx.bcx.ins().fmul(x2, x2);
-          fx.bcx.ins().fmul(x4, base_val)
-        }
-        6 => {
-          let x3 = fx.bcx.ins().fmul(x2, base_val);
-          fx.bcx.ins().fmul(x3, x3)
-        }
-        7 => {
-          let x3 = fx.bcx.ins().fmul(x2, base_val);
-          let x6 = fx.bcx.ins().fmul(x3, x3);
-          fx.bcx.ins().fmul(x6, base_val)
-        }
-        8 => {
-          let x4 = fx.bcx.ins().fmul(x2, x2);
-          fx.bcx.ins().fmul(x4, x4)
-        }
-        _ => unreachable!(),
-      });
+    if *exp == exp_u32 as f32 && exp_u32 >= 3 {
+      return Ok(fpow_by_squaring(fx, base_val, exp_u32));
     }
   }
 


### PR DESCRIPTION
The previous code hand-unrolled multiplications for exponents 3-8, which meant larger integer exponents fell through to the general `exp2(n*log2(x))` path. That path produces NaN for negative bases with odd exponents since `log2` of a negative number is undefined.

Replace the manual cases with a generic loop that handles any exponent >= 3 using the binary method. This is both shorter and supports arbitrarily large integer exponents while preserving the sign of negative bases.