### PR TITLE
codegen: use exponentiation by squaring for negative int pow

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -1037,6 +1037,24 @@ mod tests {
   }
 
   #[rstest]
+  fn test_pow_negative_integer_exponent() {
+    let src: &[&[f32]] = &[&[0.5, 2.0, 3.0, 4.0]];
+    for exp in [-1, -2, -3, -5, -8, -127] {
+      let expr = format!("x {exp} pow");
+      let out = run_expr_padded(&expr, src, None);
+      for (i, &v) in src[0].iter().enumerate() {
+        let expected = v.powi(exp);
+        assert_relative_eq!(out[0][i], expected, epsilon = 1e-4);
+      }
+    }
+  }
+
+  #[rstest]
+  fn test_pow_negative_exponent_zero_base() {
+    assert_relative_eq!(run_expr("0 2 -127 pow /"), 0.0);
+  }
+
+  #[rstest]
   #[case("2 sqrt", 2f32.sqrt())]
   #[case("3 sqrt", 3f32.sqrt())]
   fn test_sqrt(#[case] expr: &str, #[case] expected: f32) {

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -649,6 +649,19 @@ fn pow_simd(
     if *exp == exp_u32 as f32 && exp_u32 >= 3 {
       return Ok(fpow_by_squaring(fx, base_val, exp_u32));
     }
+    let exp_i32 = *exp as i32;
+    if *exp == exp_i32 as f32 && exp_i32 <= -1 {
+      let abs_exp = exp_i32.unsigned_abs();
+      let pow_abs = if abs_exp == 1 {
+        base_val
+      } else if abs_exp == 2 {
+        fx.bcx.ins().fmul(base_val, base_val)
+      } else {
+        fpow_by_squaring(fx, base_val, abs_exp)
+      };
+      let one = splat_f32(fx, 1.0);
+      return Ok(fx.bcx.ins().fdiv(one, pow_abs));
+    }
   }
 
   let exp_val = translate_expr_simd(fx, exponent)?;


### PR DESCRIPTION
This was yet another example of us falling through to the `exp(exp * ln(base))` path, this time for negative int exponents. When this happens, we do e.g. `exp(-127 * ln(2))`, and then the exp approximation would try to build `2^k` by injecting `k + 127` into the exponent field, assuming that `k + 127` would always yield a normal, positive exponent. But it doesn't in this case, so you get `pow(2, -127) = 0`, and then `0 / 0 = NaN`.