### PR TITLE
codegen: use `fcmp`+`vselect` for `min`/`max`

### DIFF
--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -1243,6 +1243,19 @@ mod tests {
   }
 
   #[rstest]
+  #[case("3 5 max", 5.0)]
+  #[case("5 3 max", 5.0)]
+  #[case("5 5 max", 5.0)]
+  #[case("-2 -7 max", -2.0)]
+  #[case("3 5 min", 3.0)]
+  #[case("5 3 min", 3.0)]
+  #[case("5 5 min", 5.0)]
+  #[case("-2 -7 min", -7.0)]
+  fn test_max_min(#[case] expr: &str, #[case] expected: f32) {
+    assert_relative_eq!(run_expr(expr), expected);
+  }
+
+  #[rstest]
   #[case("10 0 20 clip", 10.0)]
   #[case("-10 0 20 clip", 0.0)]
   #[case("30 0 20 clip", 20.0)]

--- a/crates/cranexpr-codegen/src/translate_simd.rs
+++ b/crates/cranexpr-codegen/src/translate_simd.rs
@@ -148,8 +148,8 @@ fn translate_expr_simd_inner(
         TernaryOp::Clip => {
           let min_val = b;
           let max_val = c;
-          let min_result = fx.bcx.ins().fmin(a, max_val);
-          fx.bcx.ins().fmax(min_result, min_val)
+          let min_result = fmin_simd(fx, a, max_val);
+          fmax_simd(fx, min_result, min_val)
         }
       })
     }
@@ -343,6 +343,22 @@ fn vselect_f32x4(
     .bitcast(types::I32X4, MemFlags::new(), false_val);
   let selected = fx.bcx.ins().bitselect(mask, t_bits, f_bits);
   fx.bcx.ins().bitcast(VEC_TYPE, MemFlags::new(), selected)
+}
+
+/// Vectorized maximum.
+fn fmax_simd(fx: &mut FunctionCx<'_, '_>, lhs: Value, rhs: Value) -> Value {
+  // Benchmarked as faster than Cranelift's `fmax` since we shouldn't need its
+  // full IEEE-754 semantics.
+  let cmp = fx.bcx.ins().fcmp(FloatCC::GreaterThan, lhs, rhs);
+  vselect_f32x4(fx, cmp, lhs, rhs)
+}
+
+/// Vectorized minimum.
+fn fmin_simd(fx: &mut FunctionCx<'_, '_>, lhs: Value, rhs: Value) -> Value {
+  // Benchmarked as faster than Cranelift's `fmin` since we shouldn't need its
+  // full IEEE-754 semantics.
+  let cmp = fx.bcx.ins().fcmp(FloatCC::LessThan, lhs, rhs);
+  vselect_f32x4(fx, cmp, lhs, rhs)
 }
 
 /// Returns a value with the magnitude of `mag` and the sign of `sig`.
@@ -779,8 +795,8 @@ fn codegen_float_binop_simd(
       let result = fx.bcx.ins().fcmp(float_cc, lhs, rhs);
       bool_to_float_simd(fx, result)
     }
-    BinOp::Max => fx.bcx.ins().fmax(lhs, rhs),
-    BinOp::Min => fx.bcx.ins().fmin(lhs, rhs),
+    BinOp::Max => fmax_simd(fx, lhs, rhs),
+    BinOp::Min => fmin_simd(fx, lhs, rhs),
     BinOp::And | BinOp::Or | BinOp::Xor => {
       let zero = splat_f32(fx, 0.0);
       let lhs_bool = fx.bcx.ins().fcmp(FloatCC::GreaterThan, lhs, zero);


### PR DESCRIPTION
Cranelift's `fmax`/`fmin` brings in additional overhead in order to support full IEEE-754 semantics. I don't _think_ these are needed here, so use `fcmp` + `vselect` instead.