### PR TITLE
codegen: add LUT strategy for simpler exprs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ name = "cranexpr-transforms"
 version = "0.11.0"
 dependencies = [
  "cranexpr-ast",
+ "cranexpr-parser",
  "miette",
  "thiserror",
 ]

--- a/crates/cranexpr-codegen/src/compiler.rs
+++ b/crates/cranexpr-codegen/src/compiler.rs
@@ -15,11 +15,13 @@ use cranexpr_ast::{BoundaryMode, Expr};
 use cranexpr_transforms::simplify;
 use nanoid::nanoid;
 
+use crate::CompiledExpr;
 use crate::MainFunction;
 use crate::SelectFunction;
 use crate::comment_writer::CommentWriter;
 use crate::component_type::ComponentType;
 use crate::errors::{CodegenError, CodegenResult};
+use crate::lut::LutFunction;
 use crate::pointer::Pointer;
 use crate::translate_simd::{
   SIMD_LANES, codegen_pixel_offset, load_pixel_vec_f32x4, simd_lane_offsets_f32x4,
@@ -97,7 +99,11 @@ fn create_jit_module() -> JITModule {
   JITModule::new(jit_builder)
 }
 
-/// Compiles an expression AST into a JIT-compiled function.
+/// Compiles an expression AST while selecting the best evaluation strategy.
+///
+/// The general case is a JIT-compiled SIMD loop. When the expression is a
+/// pure function of a single integer clip's current pixel, it is instead
+/// precomputed into a lookup table.
 ///
 /// # Errors
 ///
@@ -112,7 +118,7 @@ pub fn compile_jit(
   src_types: &[ComponentType],
   boundary_mode: Option<BoundaryMode>,
   required_frame_props: &[(usize, String)],
-) -> Result<MainFunction, CodegenError> {
+) -> Result<CompiledExpr, CodegenError> {
   let ast: Vec<Expr> = ast.iter().map(simplify).collect();
   let mut jit_module = create_jit_module();
   let mut main_func = build_entry_fn(
@@ -135,7 +141,13 @@ pub fn compile_jit(
   jit_module.finalize_definitions().unwrap();
 
   let finalized_main = jit_module.get_finalized_function(main_func.func_id);
-  Ok(MainFunction::from_ptr(finalized_main))
+  let main = MainFunction::from_ptr(finalized_main);
+
+  if let Some(lut) = LutFunction::try_build(&ast, &main, dst_type, src_types, required_frame_props)
+  {
+    return Ok(CompiledExpr::Lut(lut));
+  }
+  Ok(CompiledExpr::Simd(main))
 }
 
 /// Compiles an expression AST and returns the pretty-printed Cranelift IR with

--- a/crates/cranexpr-codegen/src/lib.rs
+++ b/crates/cranexpr-codegen/src/lib.rs
@@ -3,10 +3,12 @@ pub mod component_type;
 pub mod errors;
 
 mod compiler;
+mod lut;
 mod pointer;
 mod translate_simd;
 
 pub use compiler::{compile_clif, compile_disasm, compile_jit, compile_jit_select};
+pub use lut::LutFunction;
 
 type MainFunc =
   unsafe extern "C" fn(*mut u8, i64, *const *const u8, *const i64, i64, i64, i64, *const f32);
@@ -65,6 +67,54 @@ impl MainFunction {
         frame_props_ptr,
       );
     };
+  }
+}
+/// A compiled expression via some evaluation strategy.
+#[derive(Debug)]
+pub enum CompiledExpr {
+  /// JIT-compiled SIMD loop.
+  Simd(MainFunction),
+  /// Lookup table over the whole input domain.
+  Lut(LutFunction),
+}
+
+impl CompiledExpr {
+  /// Evaluates the expression over a plane.
+  ///
+  /// # Safety
+  ///
+  /// `dst`, `srcs`, and `frame_props` must be valid and match the types used
+  /// during compilation.
+  #[inline]
+  #[allow(clippy::too_many_arguments)]
+  pub unsafe fn invoke<D>(
+    &self,
+    dst: &mut [D],
+    dst_stride: i64,
+    srcs: &[*const u8],
+    src_strides: &[i64],
+    width: i32,
+    height: i32,
+    n: i32,
+    frame_props: &[f32],
+  ) {
+    match self {
+      Self::Simd(main) => unsafe {
+        main.invoke(
+          dst,
+          dst_stride,
+          srcs,
+          src_strides,
+          width,
+          height,
+          n,
+          frame_props,
+        );
+      },
+      Self::Lut(lut) => unsafe {
+        lut.invoke(dst, dst_stride, srcs, src_strides, width, height);
+      },
+    }
   }
 }
 

--- a/crates/cranexpr-codegen/src/lut.rs
+++ b/crates/cranexpr-codegen/src/lut.rs
@@ -1,0 +1,181 @@
+//! LUT compilation strategy.
+//!
+//! When an expression is a pure function of a single integer clip's current
+//! pixel, the whole expression can be evaluated once per possible input value
+//! at compile time. Runtime evaluation then boils down to a table lookup.
+
+use cranexpr_ast::Expr;
+use cranexpr_transforms::{LutVisitor, Visitor};
+
+use crate::MainFunction;
+use crate::component_type::ComponentType;
+use crate::translate_simd::resolve_clip_name;
+
+/// A compiled expression as a lookup table.
+///
+/// The table is indexed by the raw source sample and stores raw destination
+/// samples.
+#[derive(Debug)]
+pub struct LutFunction {
+  clip_idx: usize,
+  src_type: ComponentType,
+  table: LookupTable,
+}
+
+#[derive(Debug)]
+enum LookupTable {
+  U8(Vec<u8>),
+  U16(Vec<u16>),
+  F32(Vec<f32>),
+}
+
+impl LutFunction {
+  /// Builds a LUT for `ast` when it qualifies by evaluating `main` over the
+  /// whole input domain of the single referenced clip.
+  ///
+  /// Returns `None` when the expression is not a pure function of one integer
+  /// clip's current pixel.
+  pub(crate) fn try_build(
+    ast: &[Expr],
+    main: &MainFunction,
+    dst_type: ComponentType,
+    src_types: &[ComponentType],
+    required_frame_props: &[(usize, String)],
+  ) -> Option<Self> {
+    if !required_frame_props.is_empty() {
+      return None;
+    }
+
+    let mut visitor = LutVisitor::new();
+    for node in ast {
+      visitor.visit_expr(node);
+    }
+    if !visitor.eligible {
+      return None;
+    }
+    let clip_idx = resolve_clip_name(visitor.clip?, src_types).ok()?;
+    let src_type = src_types[clip_idx];
+    if !matches!(src_type, ComponentType::U8 | ComponentType::U16) {
+      return None;
+    }
+
+    // Cover every possible sample value of the source.
+    let src: Vec<u8> = match src_type {
+      ComponentType::U8 => (0..=u8::MAX).collect(),
+      ComponentType::U16 => (0..=u16::MAX).flat_map(u16::to_le_bytes).collect(),
+      ComponentType::F16 | ComponentType::F32 => unreachable!(),
+    };
+    let domain = 1usize << (src_type.bytes() * 8);
+    debug_assert_eq!(src.len(), domain * src_type.bytes());
+
+    // The expression only dereferences its single referenced clip, but the
+    // compiled function receives one pointer per input.
+    let src_ptrs = vec![src.as_ptr(); src_types.len()];
+    let src_strides = vec![src.len() as i64; src_types.len()];
+
+    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+    let width = domain as i32;
+    macro_rules! run {
+      ($t:ty) => {{
+        let mut table = vec![<$t>::default(); domain];
+        unsafe {
+          main.invoke(
+            &mut table,
+            (domain * size_of::<$t>()) as i64,
+            &src_ptrs,
+            &src_strides,
+            width,
+            1,
+            0,
+            &[],
+          );
+        }
+        table
+      }};
+    }
+    let table = match dst_type {
+      ComponentType::U8 => LookupTable::U8(run!(u8)),
+      ComponentType::U16 | ComponentType::F16 => LookupTable::U16(run!(u16)),
+      ComponentType::F32 => LookupTable::F32(run!(f32)),
+    };
+
+    Some(Self {
+      clip_idx,
+      src_type,
+      table,
+    })
+  }
+
+  /// Applies the lookup table.
+  ///
+  /// # Safety
+  ///
+  /// The caller must ensure that `dst` and `srcs` are valid and that the types
+  /// match those used during compilation.
+  #[allow(clippy::too_many_arguments)]
+  pub(crate) unsafe fn invoke<D>(
+    &self,
+    dst: &mut [D],
+    dst_stride: i64,
+    srcs: &[*const u8],
+    src_strides: &[i64],
+    width: i32,
+    height: i32,
+  ) {
+    let src_ptr = srcs[self.clip_idx];
+    let src_stride = src_strides[self.clip_idx];
+    let dst_ptr = dst.as_mut_ptr().cast::<u8>();
+    #[allow(clippy::cast_sign_loss)]
+    let (width, height) = (width as usize, height as usize);
+    let src_u16 = matches!(self.src_type, ComponentType::U16);
+
+    unsafe {
+      match (&self.table, src_u16) {
+        (LookupTable::U8(t), false) => {
+          apply_lut::<u8, u8>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+        (LookupTable::U8(t), true) => {
+          apply_lut::<u16, u8>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+        (LookupTable::U16(t), false) => {
+          apply_lut::<u8, u16>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+        (LookupTable::U16(t), true) => {
+          apply_lut::<u16, u16>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+        (LookupTable::F32(t), false) => {
+          apply_lut::<u8, f32>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+        (LookupTable::F32(t), true) => {
+          apply_lut::<u16, f32>(t, src_ptr, src_stride, dst_ptr, dst_stride, width, height);
+        }
+      }
+    }
+  }
+}
+
+/// Applies `table` row by row.
+unsafe fn apply_lut<S, D>(
+  table: &[D],
+  src_ptr: *const u8,
+  src_stride: i64,
+  dst_ptr: *mut u8,
+  dst_stride: i64,
+  width: usize,
+  height: usize,
+) where
+  S: Copy,
+  usize: From<S>,
+  D: Copy,
+{
+  for y in 0..height {
+    unsafe {
+      let src_row = src_ptr.offset(y as isize * src_stride as isize).cast::<S>();
+      let dst_row = dst_ptr.offset(y as isize * dst_stride as isize).cast::<D>();
+      for x in 0..width {
+        let s = usize::from(src_row.add(x).read());
+        dst_row.add(x).write(*table.get_unchecked(s));
+      }
+    }
+  }
+}

--- a/crates/cranexpr-transforms/Cargo.toml
+++ b/crates/cranexpr-transforms/Cargo.toml
@@ -12,5 +12,8 @@ thiserror = "=2.0.18"
 
 cranexpr-ast = { workspace = true }
 
+[dev-dependencies]
+cranexpr-parser = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/cranexpr-transforms/src/ident.rs
+++ b/crates/cranexpr-transforms/src/ident.rs
@@ -1,0 +1,7 @@
+/// Returns whether `name` refers to a clip.
+pub(crate) fn is_clip_identifier(name: &str) -> bool {
+  matches!(name.as_bytes(), [b'a'..=b'z'])
+    || name
+      .strip_prefix("src")
+      .is_some_and(|s| s.parse::<usize>().is_ok())
+}

--- a/crates/cranexpr-transforms/src/lib.rs
+++ b/crates/cranexpr-transforms/src/lib.rs
@@ -1,12 +1,15 @@
 //! AST traversal patterns, optimizations, and rewrites.
 
 mod errors;
+mod ident;
+mod lut_visitor;
 mod pixel_access_visitor;
 mod prop_visitor;
 mod simplify;
 mod visit;
 
 pub use errors::TransformError;
+pub use lut_visitor::LutVisitor;
 pub use pixel_access_visitor::PixelAccessVisitor;
 pub use prop_visitor::PropVisitor;
 pub use simplify::simplify;

--- a/crates/cranexpr-transforms/src/lut_visitor.rs
+++ b/crates/cranexpr-transforms/src/lut_visitor.rs
@@ -1,0 +1,114 @@
+use cranexpr_ast::Expr;
+
+use crate::ident::is_clip_identifier;
+use crate::visit::{Visitor, walk_expr};
+
+/// Visitor that decides whether an expression can become a lookup table.
+///
+/// An expression qualifies when it is a pure function of the current pixel of
+/// a single clip, so the whole expression can be precomputed per input value.
+///
+/// Eligible expressions may only read one clip's current pixel (`x`), use
+/// literals, arithmetic, and user variables. Anything positional (`X`, `Y`,
+/// relative/absolute pixel access), temporal (`N`), per-clip context
+/// (`width`, `height`), frame properties, or a second clip disqualifies it.
+pub struct LutVisitor<'a> {
+  /// The single clip identifier referenced so far, if any.
+  pub clip: Option<&'a str>,
+  // Whether or not the expression can become a lookup table.
+  pub eligible: bool,
+}
+
+impl LutVisitor<'_> {
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      clip: None,
+      eligible: true,
+    }
+  }
+}
+
+impl Default for LutVisitor<'_> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<'a> Visitor<'a> for LutVisitor<'a> {
+  fn visit_expr(&mut self, expr: &'a Expr) {
+    if !self.eligible {
+      return;
+    }
+    match expr {
+      Expr::RelAccess { .. } | Expr::AbsAccess { .. } | Expr::Prop(..) => {
+        self.eligible = false;
+      }
+      Expr::Ident(name) => {
+        if is_clip_identifier(name) {
+          match self.clip {
+            None => self.clip = Some(name),
+            Some(prev) if prev == name => {}
+            Some(_) => self.eligible = false,
+          }
+        } else {
+          // X, Y, N, width, height, etc.
+          self.eligible = false;
+        }
+      }
+      _ => walk_expr(self, expr),
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn check(expr: &str) -> (bool, Option<String>) {
+    let ast = cranexpr_parser::parse_expr(expr).unwrap();
+    let mut v = LutVisitor::new();
+    for node in &ast {
+      v.visit_expr(node);
+    }
+    (v.eligible, v.clip.map(str::to_owned))
+  }
+
+  #[test]
+  fn accepts_single_clip_pure_expr() {
+    let (eligible, clip) = check("x 32768 / 0.86 pow 65535 *");
+    assert!(eligible);
+    assert_eq!(clip.as_deref(), Some("x"));
+  }
+
+  #[test]
+  fn accepts_user_variables() {
+    let (eligible, clip) = check("x 2 * v! v@ v@ *");
+    assert!(eligible);
+    assert_eq!(clip.as_deref(), Some("x"));
+  }
+
+  #[test]
+  fn rejects_two_clips() {
+    assert!(!check("x y +").0);
+  }
+
+  #[test]
+  fn rejects_positional_and_temporal() {
+    assert!(!check("x X +").0);
+    assert!(!check("x Y +").0);
+    assert!(!check("x N +").0);
+    assert!(!check("x width +").0);
+  }
+
+  #[test]
+  fn rejects_pixel_access() {
+    assert!(!check("x[-1,0]").0);
+    assert!(!check("0 0 x[]").0);
+  }
+
+  #[test]
+  fn rejects_frame_props() {
+    assert!(!check("x x.PlaneStatsAverage *").0);
+  }
+}

--- a/crates/cranexpr-transforms/src/pixel_access_visitor.rs
+++ b/crates/cranexpr-transforms/src/pixel_access_visitor.rs
@@ -1,14 +1,8 @@
 use cranexpr_ast::Expr;
 
 use crate::errors::TransformError;
+use crate::ident::is_clip_identifier;
 use crate::visit::{Visitor, walk_expr};
-
-fn is_clip_identifier(name: &str) -> bool {
-  matches!(name.as_bytes(), [b'a'..=b'z'])
-    || name
-      .strip_prefix("src")
-      .is_some_and(|s| s.parse::<usize>().is_ok())
-}
 
 fn is_pixel_context_identifier(name: &str) -> bool {
   matches!(name, "X" | "Y")

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -18,7 +18,7 @@ use vapoursynth4_rs::{
   utils::is_constant_video_format,
 };
 
-use cranexpr_codegen::{MainFunction, compile_jit};
+use cranexpr_codegen::{CompiledExpr, compile_jit};
 
 use crate::{
   component_type::{ComponentType, FromVideoFormat},
@@ -37,7 +37,7 @@ pub(crate) struct CranexprFilter {
   nodes: Vec<VideoNode>,
   vi: VideoInfo,
   planes: [PlaneOp; 3],
-  bytecode: [Option<MainFunction>; 3],
+  bytecode: [Option<CompiledExpr>; 3],
   required_frame_props: [Vec<(usize, String)>; 3],
   frame_prop_keys: [Vec<Key>; 3],
 }
@@ -110,7 +110,7 @@ impl Filter for CranexprFilter {
     };
 
     let mut planes = [PlaneOp::Undefined; 3];
-    let mut bytecode: [Option<MainFunction>; 3] = [None, None, None];
+    let mut bytecode: [Option<CompiledExpr>; 3] = [None, None, None];
     let mut required_frame_props: [Vec<(usize, String)>; 3] = [Vec::new(), Vec::new(), Vec::new()];
     let mut frame_prop_keys: [Vec<Key>; 3] = [Vec::new(), Vec::new(), Vec::new()];
 


### PR DESCRIPTION
By "simpler" I mean pure functions of a single integer clip's current pixel (no spatial access, no other clips, no frame properties). In this specific case, the entire output domain is small enough to precompute at runtime.